### PR TITLE
[IBCDPE-818] Create and update e-mail templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ In order to use this workflow, you must already have completed the following ste
 
 The workflow takes the following inputs:
 
-1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in.
-2. `view_id` (required): The Synapse ID for your submission view.
-3. `input_id` (required): The Synapse ID for the folder holding the testing data for submissions.
-4. `email_with_score` (required & case-sensitive): Choose whether or not the e-mail sent out to participants will include the evaluation score or not. Can either be "yes" or "no".
-5. `cpus` (required): Number of CPUs to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `4`
-6. `memory` (required): Amount of memory to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `16.GB`
-7. `scoring_script` (required): The string name of the scoring script to use for the `SCORE` step of the workflow run. Defaults to `score.py`
-8. `validation_script` (required): The string name of the validation script to use for the `VALIDATE` step of the workflow run. Defaults to `validate.py`
+1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in. Please replace placeholder value.
+2. `view_id` (required): The Synapse ID for your submission view. Please replace placeholder value.
+3. `input_id` (required): The Synapse ID for the folder holding the testing data for submissions. Please replace placeholder value.
+4. `email_with_score` (optional & case-sensitive): Choose whether or not the e-mail sent out to participants will include the evaluation score or not. Can either be "yes" or "no". Defaults to "yes".
+5. `cpus` (optional): Number of CPUs to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `4`
+6. `memory` (optional): Amount of memory to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `16.GB`
+7. `scoring_script` (optional): The string name of the scoring script to use for the `SCORE` step of the workflow run. Defaults to `score.py`
+8. `validation_script` (optional): The string name of the validation script to use for the `VALIDATE` step of the workflow run. Defaults to `validate.py`
 
 Run the workflow locally with default inputs:
 ```

--- a/README.md
+++ b/README.md
@@ -37,12 +37,14 @@ In order to use this workflow, you must already have completed the following ste
 
 The workflow takes the following inputs:
 
-1. `view_id` (required): The Synapse ID for your submission view.
-2. `input_id` (required): The Synapse ID for the folder holding the testing data for submissions.
-3. `cpus` (required): Number of CPUs to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `4`
-4. `memory` (required): Amount of memory to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `16.GB`
-5. `scoring_script` (required): The string name of the scoring script to use for the `SCORE` step of the workflow run. Defaults to `score.py`
-6. `validation_script` (required): The string name of the validation script to use for the `VALIDATE` step of the workflow run. Defaults to `validate.py`
+1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in (case-sensitive)
+2. `view_id` (required): The Synapse ID for your submission view.
+3. `input_id` (required): The Synapse ID for the folder holding the testing data for submissions.
+4. `email_with_score` (required & case-sensitive): Choose whether or not the e-mail sent out to participants will include the evaluation score or not. Can either be "yes" or "no".
+5. `cpus` (required): Number of CPUs to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `4`
+6. `memory` (required): Amount of memory to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `16.GB`
+7. `scoring_script` (required): The string name of the scoring script to use for the `SCORE` step of the workflow run. Defaults to `score.py`
+8. `validation_script` (required): The string name of the validation script to use for the `VALIDATE` step of the workflow run. Defaults to `validate.py`
 
 Run the workflow locally with default inputs:
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ In order to use this workflow, you must already have completed the following ste
 
 The workflow takes the following inputs:
 
-1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in (case-sensitive)
+1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in.
 2. `view_id` (required): The Synapse ID for your submission view.
 3. `input_id` (required): The Synapse ID for the folder holding the testing data for submissions.
 4. `email_with_score` (required & case-sensitive): Choose whether or not the e-mail sent out to participants will include the evaluation score or not. Can either be "yes" or "no".

--- a/bin/build_update_subfolders.py
+++ b/bin/build_update_subfolders.py
@@ -107,7 +107,7 @@ def build_update_subfolders(
 
     project_id = syn.findEntityId(name=project_name)
     parent_folder_id = syn.findEntityId(name=parent_folder, parent=project_id)
-    submitter_id = send_email.get_participant_id(syn, submission_id)[0]
+    submitter_id = send_email.SendEmail().get_participant_id(syn, submission_id)[0]
 
     if build_or_update == "build":
         # Creating the level 1 (directly under Parent-Folder/) subfolder, which is named

--- a/bin/build_update_subfolders.py
+++ b/bin/build_update_subfolders.py
@@ -107,7 +107,7 @@ def build_update_subfolders(
 
     project_id = syn.findEntityId(name=project_name)
     parent_folder_id = syn.findEntityId(name=parent_folder, parent=project_id)
-    submitter_id = send_email.SendEmail().get_participant_id(submission_id)[0]
+    submitter_id = send_email.get_participant_id(syn, submission_id)[0]
 
     if build_or_update == "build":
         # Creating the level 1 (directly under Parent-Folder/) subfolder, which is named

--- a/bin/build_update_subfolders.py
+++ b/bin/build_update_subfolders.py
@@ -107,7 +107,7 @@ def build_update_subfolders(
 
     project_id = syn.findEntityId(name=project_name)
     parent_folder_id = syn.findEntityId(name=parent_folder, parent=project_id)
-    submitter_id = send_email.SendEmail().get_participant_id(syn, submission_id)[0]
+    submitter_id = send_email.SendEmail().get_participant_id(submission_id)[0]
 
     if build_or_update == "build":
         # Creating the level 1 (directly under Parent-Folder/) subfolder, which is named

--- a/bin/score.py
+++ b/bin/score.py
@@ -17,22 +17,26 @@ def score_submission(predictions_path: str, status: str) -> dict:
     """
     if status == "INVALID":
         score_status = "INVALID"
-        score = None
+        score1, score2, score3 = None, None, None
     else:
         # placeholder file reading
         with open(predictions_path, "r") as sub_file:
             predictions_contents = sub_file.read()
         try:
             # placeholder scoring
-            score = 1 + 1
+            score1 = 1 + 1
+            score2 = score1 * 2
+            score3 = score1 * 3
             score_status = "SCORED"
             message = ""
         except Exception as e:
             message = f"Error {e} occurred while scoring"
-            score = None
+            score1, score2, score3 = None, None, None
             score_status = "INVALID"
     result = {
-        "auc": score,
+        "score1": score1,
+        "score2": score2,
+        "score3": score3,
         "score_status": score_status,
         "score_errors": message,
     }

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -87,7 +87,7 @@ def email_template(
         + "Please contact the organizers for more information.",
     }
 
-    body = templates.get((status, email_with_score.lower()))
+    body = templates.get((status, email_with_score))
 
     # If there is a typo in ``email_with_score``, ``body`` will be None;
     # Raise an error if so, to avoid sending empty e-mails...

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -93,7 +93,7 @@ def email_template(
     # Raise an error if so, to avoid sending empty e-mails...
     if body is None:
         raise ValueError(
-            f"``email_with_score`` can either be yes/no. Got {email_with_score}."
+            f"Incorrect status and/or email_with_score arguments. Got status: {status}, email_with_score: {email_with_score}."
         )
 
     return body

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -36,6 +36,15 @@ def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[s
     return [participant_id]
 
 
+def get_score_dict(score):
+        strs = [""]
+        for key in score.keys():
+            str = f"{key} : {score[key][0]}"+"\n"
+            strs.append(str)
+
+        return strs
+
+
 def email_template(
     status: str,
     email_with_score: bool,
@@ -60,20 +69,11 @@ def email_template(
       A string for that represents the body of the e-mail to be sent out to submitting team or individual.
 
     """
-    def get_score_dict(score):
-        strs = [""]
-        for key in score.keys():
-            str = f"{key} : {score[key][0]}"+"\n"
-            strs.append(str)
-
-        return strs
-
     templates = {
         (
             "VALIDATED",
             "yes",
         ):
-        #f"Submission {submission_id} has been evaluated with the following scores:"+"\n"+"View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
         f"Submission {submission_id} has been evaluated with the following scores:\n" + "\n".join(get_score_dict(score)) + f"\nView all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
         (
             "VALIDATED",

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -60,10 +60,13 @@ def email_template(
       A string for that represents the body of the e-mail to be sent out to submitting team or individual.
 
     """
-    strs = [""]
-    for key in score.keys():
-        str = f"{key} : {score[key][0]}"+"\n"
-        strs.append(str)
+    def get_score_dict(score):
+        strs = [""]
+        for key in score.keys():
+            str = f"{key} : {score[key][0]}"+"\n"
+            strs.append(str)
+
+        return strs
 
     templates = {
         (
@@ -71,7 +74,7 @@ def email_template(
             "yes",
         ):
         #f"Submission {submission_id} has been evaluated with the following scores:"+"\n"+"View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
-        f"Submission {submission_id} has been evaluated with the following scores:\n" + "\n".join(strs) + f"\nView all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
+        f"Submission {submission_id} has been evaluated with the following scores:\n" + "\n".join(get_score_dict(score)) + f"\nView all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
         (
             "VALIDATED",
             "no",

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -89,7 +89,7 @@ def email_template(
 def send_email(view_id: str, submission_id: str, email_with_score: bool):
     """
     Sends an e-mail on the status of the individual submission
-    to the participant team or participant individual.
+    to the submitting team or individual.
 
     Arguments:
       view_id: The view Id of the Submission View on Synapse

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -7,6 +7,11 @@ from typing import List
 
 
 class SendEmail:
+
+    def __init__(self):
+        # Establish access to the Synapse API
+        self.syn = synapseclient.login()
+
     def get_participant_id(self, submission_id: str) -> List[str]:
         """
         Retrieves the teamId of the participating team that made
@@ -116,9 +121,6 @@ class SendEmail:
           submission_id: The ID for an individual submission within an evaluation queue
 
         """
-        # Initialize bridge to Synapse API
-        self.syn = synapseclient.login()
-
         # Get MODEL_TO_DATA annotations for the given submission
         self.get_annotations(submission_id)
 

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -6,126 +6,150 @@ import synapseclient
 from typing import List
 
 
-def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[str]:
-    """
-    Retrieves the teamId of the participating team that made
-    the submission. If the submitter is an individual rather than
-    a team, the userId for the individual is retrieved.
+class SendEmail:
+    def get_participant_id(self, submission_id: str) -> List[str]:
+        """
+        Retrieves the teamId of the participating team that made
+        the submission. If the submitter is an individual rather than
+        a team, the userId for the individual is retrieved.
 
-    Arguments:
-      syn: A Synapse Python client instance
-      submission_id: The ID for an individual submission within an evaluation queue
+        Arguments:
+          syn: A Synapse Python client instance
+          submission_id: The ID for an individual submission within an evaluation queue
 
-    Returns:
-      Returns the synID of a team or individual participant
-    """
-    # Retrieve a Submission object
-    submission = syn.getSubmission(submission_id, downloadFile=False)
+        Returns:
+          Returns the synID of a team or individual participant
+        """
+        # Retrieve a Submission object
+        submission = self.syn.getSubmission(submission_id, downloadFile=False)
 
-    # Get the teamId or userId of submitter
-    participant_id = submission.get("teamId") or submission.get("userId")
+        # Get the teamId or userId of submitter
+        participant_id = submission.get("teamId") or submission.get("userId")
 
-    # Ensure that the participant_id returned is a list
-    # so it can be fed into syn.sendMessage(...) later.
-    return [participant_id]
+        # Ensure that the participant_id returned is a list
+        # so it can be fed into syn.sendMessage(...) later.
+        return [participant_id]
 
+    def email_template(
+        self,
+        status: str,
+        email_with_score: bool,
+        submission_id: str,
+        view_id: str,
+        score: int,
+        reason: str,
+    ) -> str:
+        """
+        Selects a pre-defined e-mail template based on user-fed email_with_score, and the validation
+        status of the particular submission.
 
-def email_template(
-    status: str,
-    email_with_score: bool,
-    submission_id: str,
-    view_id: str,
-    score: int,
-    reason: str,
-) -> str:
-    """
-    Selects a pre-defined e-mail template based on user-fed email_with_score, and the validation
-    status of the particular submission.
+        Arguments:
+          status: The submission status
+          email_with_score: '0' if e-mail should not include score value / link to submissions views
+          submission_id: The submission ID of the given submission on Synapse
+          view_id: The Submission view ID on Synapse
+          score: The score value of the submission
+          reason: The reason for the validation error, if present.
 
-    Arguments:
-      status: The submission status
-      email_with_score: '0' if e-mail should not include score value / link to submissions views
-      submission_id: The submission ID of the given submission on Synapse
-      view_id: The Submission view ID on Synapse
-      score: The score value of the submission
-      reason: The reason for the validation error, if present.
+        Returns:
+          A string for that represents the body of the e-mail to be sent out to submitting team or individual.
 
-    Returns:
-      A string for that represents the body of the e-mail to be sent out to submitting team or individual.
+        """
+        templates = {
+            (
+                "VALIDATED",
+                "1",
+            ): f"Submission {submission_id} has been evaluated with a score value of {str(score)}. View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
+            (
+                "VALIDATED",
+                "0",
+            ): f"Submission {submission_id} has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
+            (
+                "INVALID",
+                "1",
+            ): f"Evaluation failed for Submission {submission_id}."
+            + "\n"
+            + f"Reason: '{reason}'."
+            + "\n"
+            + f"View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/, and contact the organizers for more information.",
+            (
+                "INVALID",
+                "0",
+            ): f"Evaluation failed for Submission {submission_id}."
+            + "\n"
+            + f"Reason: '{reason}'."
+            + "\n"
+            + "Please contact the organizers for more information.",
+        }
 
-    """
-    templates = {
-        (
-            "VALIDATED",
-            "1",
-        ): f"Submission {submission_id} has been evaluated with a score value of {str(score)}. View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
-        (
-            "VALIDATED",
-            "0",
-        ): f"Submission {submission_id} has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
-        (
-            "INVALID",
-            "1",
-        ): f"Evaluation failed for Submission {submission_id}."
-        + "\n"
-        + f"Reason: '{reason}'."
-        + "\n"
-        + f"View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/, and contact the organizers for more information.",
-        (
-            "INVALID",
-            "0",
-        ): f"Evaluation failed for Submission {submission_id}."
-        + "\n"
-        + f"Reason: '{reason}'."
-        + "\n"
-        + "Please contact the organizers for more information.",
-    }
+        body = templates.get((status, email_with_score))
 
-    body = templates.get((status, email_with_score))
+        return body
 
-    return body
+    def get_annotations(self, submission_id: str):
+        """
+        Gets the ``status`` ``score`` and ``reason`` annotations for the given
+        submission on Synapse and makes them attributes of the class instance.
 
+        1. ``status`` is the submission status, as defined by the last begun stage
+        in the MODEL_TO_SYNAPSE workflow.
+        2. ``score`` is the score of the model, used to determine its accuracy.
+        3. ``reason`` is the reason for the validation error, if there was one.
+        It remains an empty string (None) if no validation error.
+        """
+        submission_annotations = self.syn.getSubmissionStatus(submission_id)[
+            "submissionAnnotations"
+        ]
+        # TODO: "auc" may not always be the annotation name for score.
+        # Should enforce annotation names in the score/validation scripts.
+        self.status = submission_annotations.get("validation_status")[0]
+        self.score = submission_annotations.get("auc")[0]
+        self.reason = submission_annotations.get("validation_errors")[0]
 
-def send_email(view_id: str, submission_id: str, email_with_score: bool):
-    """
-    Sends an e-mail on the status of the individual submission
-    to the submitting team or individual.
+    def send_email(self, view_id: str, submission_id: str, email_with_score: str):
+        """
+        Sends an e-mail on the status of the individual submission
+        to the submitting team or individual.
 
-    Arguments:
-      view_id: The view Id of the Submission View on Synapse
-      submission_id: The ID for an individual submission within an evaluation queue
+        Arguments:
+          view_id: The view Id of the Submission View on Synapse
+          submission_id: The ID for an individual submission within an evaluation queue
 
-    """
-    syn = synapseclient.login()
+        """
+        # Initialize bridge to Synapse API
+        self.syn = synapseclient.login()
 
-    submission_annotations = syn.getSubmissionStatus(submission_id)[
-        "submissionAnnotations"
-    ]
-    # TODO: "auc" may not always be the annotation name for score.
-    # Should enforce annotation names in the score/validation scripts.
-    status = submission_annotations.get("validation_status")[0]
-    score = submission_annotations.get("auc")[0]
-    reason = submission_annotations.get("validation_errors")[0]
+        # Get MODEL_TO_DATA annotations for the given submission
+        self.get_annotations(submission_id)
 
-    # Get the synapse users to send an e-mail to
-    ids_to_notify = get_participant_id(syn, submission_id)
+        # Get the Synapse users to send an e-mail to
+        ids_to_notify = self.get_participant_id(submission_id)
 
-    # Sends an e-mail notifying participant(s) that the evaluation succeeded or failed
-    # depending on status
-    subject = (
-        f"Evaluation Success: {submission_id}"
-        if status == "VALIDATED"
-        else f"Evaluation Failed: {submission_id}"
-    )
-    body = email_template(
-        status, email_with_score, submission_id, view_id, score, reason
-    )
+        # Create the subject and body of the e-mail message, depending on submission status
+        subject = (
+            f"Evaluation Success: {submission_id}"
+            if self.status == "VALIDATED"
+            else f"Evaluation Failed: {submission_id}"
+        )
+        body = self.email_template(
+            self.status,
+            email_with_score,
+            submission_id,
+            view_id,
+            self.score,
+            self.reason,
+        )
 
-    syn.sendMessage(userIds=ids_to_notify, messageSubject=subject, messageBody=body)
+        # Sends an e-mail notifying participant(s) that the evaluation succeeded or failed
+        self.syn.sendMessage(
+            userIds=ids_to_notify, messageSubject=subject, messageBody=body
+        )
 
 
 if __name__ == "__main__":
     view_id = sys.argv[1]
     submission_id = sys.argv[2]
     email_with_score = sys.argv[3]
-    send_email(view_id, submission_id, email_with_score)
+
+    sendemail = SendEmail()
+    sendemail.send_email(view_id, submission_id, email_with_score)

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -38,6 +38,22 @@ def email_template(
     score: int,
     reason: str,
 ) -> str:
+    """
+    Selects a pre-defined e-mail template based on user-fed email_with_score, and the validation
+    status of the particular submission.
+
+    Arguments:
+      status: The submission status
+      email_with_score: '0' if e-mail should not include score value / link to submissions views
+      submission_id: The submission ID of the given submission on Synapse
+      view_id: The Submission view ID on Synapse
+      score: The score value of the submission
+      reason: The reason for the validation error, if present.
+
+    Returns:
+      A string for that represents the body of the e-mail to be sent out to submitting team or individual.
+
+    """
     templates = {
         (
             "VALIDATED",
@@ -50,11 +66,19 @@ def email_template(
         (
             "INVALID",
             "1",
-        ): f"Evaluation failed for Submission {submission_id}. Reason: {reason}. View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/. Please contact the organizers for more information.",
+        ): f"Evaluation failed for Submission {submission_id}."
+        + "\n"
+        + f"Reason: '{reason}'."
+        + "\n"
+        + f"View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/, and contact the organizers for more information.",
         (
             "INVALID",
             "0",
-        ): f"Evaluation failed for Submission {submission_id}. Reason: {reason}. Please contact the organizers for more information.",
+        ): f"Evaluation failed for Submission {submission_id}."
+        + "\n"
+        + f"Reason: '{reason}'."
+        + "\n"
+        + "Please contact the organizers for more information.",
     }
 
     body = templates.get((status, email_with_score))
@@ -77,8 +101,9 @@ def send_email(view_id: str, submission_id: str, email_with_score: bool):
     submission_annotations = syn.getSubmissionStatus(submission_id)[
         "submissionAnnotations"
     ]
+    # TODO: "auc" may not always be the annotation name for score.
+    # Should enforce annotation names in the score/validation scripts.
     status = submission_annotations.get("validation_status")[0]
-    # TODO: "auc" may not always be the annotation name for score. How to generalize?
     score = submission_annotations.get("auc")[0]
     reason = submission_annotations.get("validation_errors")[0]
 

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -52,7 +52,7 @@ def email_template(
       status: The submission status
       email_with_score: '0' if e-mail should not include score value / link to submissions views
       submission_id: The submission ID of the given submission on Synapse
-      view_id: The Submission view ID on Synapse
+      view_id: The submission view ID on Synapse
       score: The score value of the submission
       reason: The reason for the validation error, if present.
 

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -70,17 +70,17 @@ def send_email(view_id: str, submission_id: str, email_with_score: bool):
     Arguments:
       view_id: The view Id of the Submission View on Synapse
       submission_id: The ID for an individual submission within an evaluation queue
+
     """
     syn = synapseclient.login()
-    # TODO: Consolidate calls to submission Annotations
-    status = syn.getSubmissionStatus(submission_id)["submissionAnnotations"][
-        "validation_status"
-    ][0]
+
+    submission_annotations = syn.getSubmissionStatus(submission_id)[
+        "submissionAnnotations"
+    ]
+    status = submission_annotations.get("validation_status")[0]
     # TODO: "auc" may not always be the annotation name for score. How to generalize?
-    score = syn.getSubmissionStatus(submission_id)["submissionAnnotations"]["auc"][0]
-    reason = syn.getSubmissionStatus(submission_id)["submissionAnnotations"][
-        "validation_errors"
-    ][0]
+    score = submission_annotations.get("auc")[0]
+    reason = submission_annotations.get("validation_errors")[0]
 
     # Get the synapse users to send an e-mail to
     ids_to_notify = get_participant_id(syn, submission_id)

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -6,7 +6,6 @@ import synapseclient
 from typing import List, NamedTuple
 
 
-
 class SubmissionAnnotations(NamedTuple):
     status: str
     score: int
@@ -64,15 +63,15 @@ def email_template(
     templates = {
         (
             "VALIDATED",
-            "1",
+            "yes",
         ): f"Submission {submission_id} has been evaluated with a score value of {str(score)}. View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
         (
             "VALIDATED",
-            "0",
+            "no",
         ): f"Submission {submission_id} has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
         (
             "INVALID",
-            "1",
+            "yes",
         ): f"Evaluation failed for Submission {submission_id}."
         + "\n"
         + f"Reason: '{reason}'."
@@ -80,7 +79,7 @@ def email_template(
         + f"View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/, and contact the organizers for more information.",
         (
             "INVALID",
-            "0",
+            "no",
         ): f"Evaluation failed for Submission {submission_id}."
         + "\n"
         + f"Reason: '{reason}'."
@@ -88,7 +87,12 @@ def email_template(
         + "Please contact the organizers for more information.",
     }
 
-    body = templates.get((status, email_with_score))
+    body = templates.get((status, email_with_score.lower()))
+
+    # If there is a typo in ``email_with_score``, ``body`` will be None;
+    # Raise an error if so, to avoid sending empty e-mails...
+    if body is None:
+        raise ValueError(f'``email_with_score`` can either be yes/no. Got {email_with_score}.')
 
     return body
 

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -159,7 +159,7 @@ def send_email(view_id: str, submission_id: str, email_with_score: str):
     )
 
     # Sends an e-mail notifying participant(s) that the evaluation succeeded or failed
-    message = syn.sendMessage(
+    syn.sendMessage(
         userIds=ids_to_notify, messageSubject=subject, messageBody=body
     )
 

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -50,7 +50,7 @@ def email_template(
 
     Arguments:
       status: The submission status
-      email_with_score: '0' if e-mail should not include score value / link to submissions views
+      email_with_score: "no" if e-mail should not include score value / link to submissions views. Otherwise "yes".
       submission_id: The submission ID of the given submission on Synapse
       view_id: The submission view ID on Synapse
       score: The score value of the submission
@@ -92,7 +92,9 @@ def email_template(
     # If there is a typo in ``email_with_score``, ``body`` will be None;
     # Raise an error if so, to avoid sending empty e-mails...
     if body is None:
-        raise ValueError(f'``email_with_score`` can either be yes/no. Got {email_with_score}.')
+        raise ValueError(
+            f"``email_with_score`` can either be yes/no. Got {email_with_score}."
+        )
 
     return body
 
@@ -100,7 +102,7 @@ def email_template(
 def get_annotations(syn: synapseclient.Synapse, submission_id: str) -> NamedTuple:
     """
     Gets the ``status`` ``score`` and ``reason`` annotations for the given
-    submission on Synapse and makes them attributes of the class instance.
+    submission on Synapse.
 
     1. ``status`` is the submission status, as defined by the last begun stage
     in the MODEL_TO_SYNAPSE workflow.
@@ -117,7 +119,9 @@ def get_annotations(syn: synapseclient.Synapse, submission_id: str) -> NamedTupl
     submission_score = submission_annotations.get("auc")[0]
     error_reason = submission_annotations.get("validation_errors")[0]
 
-    return SubmissionAnnotations(status=submission_status, score=submission_score, reason=error_reason)
+    return SubmissionAnnotations(
+        status=submission_status, score=submission_score, reason=error_reason
+    )
 
 
 def send_email(view_id: str, submission_id: str, email_with_score: str):
@@ -155,7 +159,7 @@ def send_email(view_id: str, submission_id: str, email_with_score: str):
     )
 
     # Sends an e-mail notifying participant(s) that the evaluation succeeded or failed
-    syn.sendMessage(
+    message = syn.sendMessage(
         userIds=ids_to_notify, messageSubject=subject, messageBody=body
     )
 
@@ -164,5 +168,5 @@ if __name__ == "__main__":
     view_id = sys.argv[1]
     submission_id = sys.argv[2]
     email_with_score = sys.argv[3]
-    
+
     send_email(view_id, submission_id, email_with_score)

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -3,155 +3,162 @@
 import sys
 import synapseclient
 
-from typing import List
+from typing import List, NamedTuple
 
 
-class SendEmail:
 
-    def __init__(self):
-        # Establish access to the Synapse API
-        self.syn = synapseclient.login()
+class SubmissionAnnotations(NamedTuple):
+    status: str
+    score: int
+    reason: str
 
-    def get_participant_id(self, submission_id: str) -> List[str]:
-        """
-        Retrieves the teamId of the participating team that made
-        the submission. If the submitter is an individual rather than
-        a team, the userId for the individual is retrieved.
 
-        Arguments:
-          syn: A Synapse Python client instance
-          submission_id: The ID for an individual submission within an evaluation queue
+def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[str]:
+    """
+    Retrieves the teamId of the participating team that made
+    the submission. If the submitter is an individual rather than
+    a team, the userId for the individual is retrieved.
 
-        Returns:
-          Returns the synID of a team or individual participant
-        """
-        # Retrieve a Submission object
-        submission = self.syn.getSubmission(submission_id, downloadFile=False)
+    Arguments:
+      syn: A Synapse Python client instance
+      submission_id: The ID for an individual submission within an evaluation queue
 
-        # Get the teamId or userId of submitter
-        participant_id = submission.get("teamId") or submission.get("userId")
+    Returns:
+      Returns the synID of a team or individual participant
+    """
+    # Retrieve a Submission object
+    submission = syn.getSubmission(submission_id, downloadFile=False)
 
-        # Ensure that the participant_id returned is a list
-        # so it can be fed into syn.sendMessage(...) later.
-        return [participant_id]
+    # Get the teamId or userId of submitter
+    participant_id = submission.get("teamId") or submission.get("userId")
 
-    def email_template(
-        self,
-        status: str,
-        email_with_score: bool,
-        submission_id: str,
-        view_id: str,
-        score: int,
-        reason: str,
-    ) -> str:
-        """
-        Selects a pre-defined e-mail template based on user-fed email_with_score, and the validation
-        status of the particular submission.
+    # Ensure that the participant_id returned is a list
+    # so it can be fed into syn.sendMessage(...) later.
+    return [participant_id]
 
-        Arguments:
-          status: The submission status
-          email_with_score: '0' if e-mail should not include score value / link to submissions views
-          submission_id: The submission ID of the given submission on Synapse
-          view_id: The Submission view ID on Synapse
-          score: The score value of the submission
-          reason: The reason for the validation error, if present.
 
-        Returns:
-          A string for that represents the body of the e-mail to be sent out to submitting team or individual.
+def email_template(
+    status: str,
+    email_with_score: bool,
+    submission_id: str,
+    view_id: str,
+    score: int,
+    reason: str,
+) -> str:
+    """
+    Selects a pre-defined e-mail template based on user-fed email_with_score, and the validation
+    status of the particular submission.
 
-        """
-        templates = {
-            (
-                "VALIDATED",
-                "1",
-            ): f"Submission {submission_id} has been evaluated with a score value of {str(score)}. View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
-            (
-                "VALIDATED",
-                "0",
-            ): f"Submission {submission_id} has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
-            (
-                "INVALID",
-                "1",
-            ): f"Evaluation failed for Submission {submission_id}."
-            + "\n"
-            + f"Reason: '{reason}'."
-            + "\n"
-            + f"View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/, and contact the organizers for more information.",
-            (
-                "INVALID",
-                "0",
-            ): f"Evaluation failed for Submission {submission_id}."
-            + "\n"
-            + f"Reason: '{reason}'."
-            + "\n"
-            + "Please contact the organizers for more information.",
-        }
+    Arguments:
+      status: The submission status
+      email_with_score: '0' if e-mail should not include score value / link to submissions views
+      submission_id: The submission ID of the given submission on Synapse
+      view_id: The Submission view ID on Synapse
+      score: The score value of the submission
+      reason: The reason for the validation error, if present.
 
-        body = templates.get((status, email_with_score))
+    Returns:
+      A string for that represents the body of the e-mail to be sent out to submitting team or individual.
 
-        return body
+    """
+    templates = {
+        (
+            "VALIDATED",
+            "1",
+        ): f"Submission {submission_id} has been evaluated with a score value of {str(score)}. View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
+        (
+            "VALIDATED",
+            "0",
+        ): f"Submission {submission_id} has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
+        (
+            "INVALID",
+            "1",
+        ): f"Evaluation failed for Submission {submission_id}."
+        + "\n"
+        + f"Reason: '{reason}'."
+        + "\n"
+        + f"View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/, and contact the organizers for more information.",
+        (
+            "INVALID",
+            "0",
+        ): f"Evaluation failed for Submission {submission_id}."
+        + "\n"
+        + f"Reason: '{reason}'."
+        + "\n"
+        + "Please contact the organizers for more information.",
+    }
 
-    def get_annotations(self, submission_id: str):
-        """
-        Gets the ``status`` ``score`` and ``reason`` annotations for the given
-        submission on Synapse and makes them attributes of the class instance.
+    body = templates.get((status, email_with_score))
 
-        1. ``status`` is the submission status, as defined by the last begun stage
-        in the MODEL_TO_SYNAPSE workflow.
-        2. ``score`` is the score of the model, used to determine its accuracy.
-        3. ``reason`` is the reason for the validation error, if there was one.
-        It remains an empty string (None) if no validation error.
-        """
-        submission_annotations = self.syn.getSubmissionStatus(submission_id)[
-            "submissionAnnotations"
-        ]
-        # TODO: "auc" may not always be the annotation name for score.
-        # Should enforce annotation names in the score/validation scripts.
-        self.status = submission_annotations.get("validation_status")[0]
-        self.score = submission_annotations.get("auc")[0]
-        self.reason = submission_annotations.get("validation_errors")[0]
+    return body
 
-    def send_email(self, view_id: str, submission_id: str, email_with_score: str):
-        """
-        Sends an e-mail on the status of the individual submission
-        to the submitting team or individual.
 
-        Arguments:
-          view_id: The view Id of the Submission View on Synapse
-          submission_id: The ID for an individual submission within an evaluation queue
+def get_annotations(syn: synapseclient.Synapse, submission_id: str) -> NamedTuple:
+    """
+    Gets the ``status`` ``score`` and ``reason`` annotations for the given
+    submission on Synapse and makes them attributes of the class instance.
 
-        """
-        # Get MODEL_TO_DATA annotations for the given submission
-        self.get_annotations(submission_id)
+    1. ``status`` is the submission status, as defined by the last begun stage
+    in the MODEL_TO_SYNAPSE workflow.
+    2. ``score`` is the score of the model, used to determine its accuracy.
+    3. ``reason`` is the reason for the validation error, if there was one.
+    It remains an empty string (None) if no validation error.
+    """
+    submission_annotations = syn.getSubmissionStatus(submission_id)[
+        "submissionAnnotations"
+    ]
+    # TODO: "auc" may not always be the annotation name for score.
+    # Should enforce annotation names in the score/validation scripts.
+    submission_status = submission_annotations.get("validation_status")[0]
+    submission_score = submission_annotations.get("auc")[0]
+    error_reason = submission_annotations.get("validation_errors")[0]
 
-        # Get the Synapse users to send an e-mail to
-        ids_to_notify = self.get_participant_id(submission_id)
+    return SubmissionAnnotations(status=submission_status, score=submission_score, reason=error_reason)
 
-        # Create the subject and body of the e-mail message, depending on submission status
-        subject = (
-            f"Evaluation Success: {submission_id}"
-            if self.status == "VALIDATED"
-            else f"Evaluation Failed: {submission_id}"
-        )
-        body = self.email_template(
-            self.status,
-            email_with_score,
-            submission_id,
-            view_id,
-            self.score,
-            self.reason,
-        )
 
-        # Sends an e-mail notifying participant(s) that the evaluation succeeded or failed
-        self.syn.sendMessage(
-            userIds=ids_to_notify, messageSubject=subject, messageBody=body
-        )
+def send_email(view_id: str, submission_id: str, email_with_score: str):
+    """
+    Sends an e-mail on the status of the individual submission
+    to the submitting team or individual.
+
+    Arguments:
+      view_id: The view Id of the Submission View on Synapse
+      submission_id: The ID for an individual submission within an evaluation queue
+
+    """
+    # Initiate connection to Synapse
+    syn = synapseclient.login()
+
+    # Get MODEL_TO_DATA annotations for the given submission
+    submission_annotations = get_annotations(syn, submission_id)
+
+    # Get the Synapse users to send an e-mail to
+    ids_to_notify = get_participant_id(syn, submission_id)
+
+    # Create the subject and body of the e-mail message, depending on submission status
+    subject = (
+        f"Evaluation Success: {submission_id}"
+        if submission_annotations.status == "VALIDATED"
+        else f"Evaluation Failed: {submission_id}"
+    )
+    body = email_template(
+        submission_annotations.status,
+        email_with_score,
+        submission_id,
+        view_id,
+        submission_annotations.score,
+        submission_annotations.reason,
+    )
+
+    # Sends an e-mail notifying participant(s) that the evaluation succeeded or failed
+    syn.sendMessage(
+        userIds=ids_to_notify, messageSubject=subject, messageBody=body
+    )
 
 
 if __name__ == "__main__":
     view_id = sys.argv[1]
     submission_id = sys.argv[2]
     email_with_score = sys.argv[3]
-
-    sendemail = SendEmail()
-    sendemail.send_email(view_id, submission_id, email_with_score)
+    
+    send_email(view_id, submission_id, email_with_score)

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -41,19 +41,19 @@ def email_template(
     templates = {
         (
             "VALIDATED",
-            "True",
+            "1",
         ): f"Submission {submission_id} has been evaluated with a score value of {str(score)}. View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
         (
             "VALIDATED",
-            "False",
+            "0",
         ): f"Submission {submission_id} has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
         (
             "INVALID",
-            "True",
+            "1",
         ): f"Evaluation failed for Submission {submission_id}. Reason: {reason}. View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/. Please contact the organizers for more information.",
         (
             "INVALID",
-            "False",
+            "0",
         ): f"Evaluation failed for Submission {submission_id}. Reason: {reason}. Please contact the organizers for more information.",
     }
 

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -30,7 +30,39 @@ def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[s
     return [participant_id]
 
 
-def send_email(view_id: str, submission_id: str):
+def email_template(
+    status: str,
+    email_with_score: bool,
+    submission_id: str,
+    view_id: str,
+    score: int,
+    reason: str,
+) -> str:
+    templates = {
+        (
+            "VALIDATED",
+            "True",
+        ): f"Submission {submission_id} has been evaluated with a score value of {str(score)}. View all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
+        (
+            "VALIDATED",
+            "False",
+        ): f"Submission {submission_id} has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
+        (
+            "INVALID",
+            "True",
+        ): f"Evaluation failed for Submission {submission_id}. Reason: {reason}. View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/. Please contact the organizers for more information.",
+        (
+            "INVALID",
+            "False",
+        ): f"Evaluation failed for Submission {submission_id}. Reason: {reason}. Please contact the organizers for more information.",
+    }
+
+    body = templates.get((status, email_with_score))
+
+    return body
+
+
+def send_email(view_id: str, submission_id: str, email_with_score: bool):
     """
     Sends an e-mail on the status of the individual submission
     to the participant team or participant individual.
@@ -40,26 +72,35 @@ def send_email(view_id: str, submission_id: str):
       submission_id: The ID for an individual submission within an evaluation queue
     """
     syn = synapseclient.login()
-    status = syn.getSubmissionStatus(submission_id)["submissionAnnotations"]["validation_status"]
+    # TODO: Consolidate calls to submission Annotations
+    status = syn.getSubmissionStatus(submission_id)["submissionAnnotations"][
+        "validation_status"
+    ][0]
+    # TODO: "auc" may not always be the annotation name for score. How to generalize?
+    score = syn.getSubmissionStatus(submission_id)["submissionAnnotations"]["auc"][0]
+    reason = syn.getSubmissionStatus(submission_id)["submissionAnnotations"][
+        "validation_errors"
+    ][0]
 
     # Get the synapse users to send an e-mail to
     ids_to_notify = get_participant_id(syn, submission_id)
 
-    # Sends an e-mail notifying participant(s) that the evaluation succeeded
-    if status == ["VALIDATED"]:
-      subject = f"Evaluation Success: {submission_id}"
-      body = f"Submission {submission_id} has been evaluated. View your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/"
+    # Sends an e-mail notifying participant(s) that the evaluation succeeded or failed
+    # depending on status
+    subject = (
+        f"Evaluation Success: {submission_id}"
+        if status == "VALIDATED"
+        else f"Evaluation Failed: {submission_id}"
+    )
+    body = email_template(
+        status, email_with_score, submission_id, view_id, score, reason
+    )
 
-    # Otherwise, send an error message to participant(s) and engineers of the infrastructure
-    else:
-      subject = f"Evaluation Failed: {submission_id}"
-      body = f"Evaluation failed for Submission {submission_id}. Submission was left with a validation status of {status}. View your submissions here: https://www.synapse.org/#!Synapse:{view_id}/tables/"
+    syn.sendMessage(userIds=ids_to_notify, messageSubject=subject, messageBody=body)
 
-    syn.sendMessage(userIds=ids_to_notify,
-                    messageSubject=subject,
-                    messageBody=body)
 
 if __name__ == "__main__":
     view_id = sys.argv[1]
     submission_id = sys.argv[2]
-    send_email(view_id, submission_id)
+    email_with_score = sys.argv[3]
+    send_email(view_id, submission_id, email_with_score)

--- a/modules/send_email.nf
+++ b/modules/send_email.nf
@@ -6,10 +6,11 @@ process SEND_EMAIL {
     input:
     val view_id
     val submission_id
+    val email_with_score
     val ready
 
     script:
     """
-    send_email.py '${view_id}' '${submission_id}'
+    send_email.py '${view_id}' '${submission_id}' '${email_with_score}'
     """
 }

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -9,7 +9,7 @@ params.view_id = "syn53475818"
 // Synapse ID for Input Data folder
 params.input_id = "syn51390589"
 // E-mail template (case-sensitive. "no" to send e-mail without score update, "yes" to send an e-mail with)
-params.email_with_score = "No"
+params.email_with_score = "no"
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER
@@ -43,15 +43,15 @@ workflow MODEL_TO_DATA {
     image_ch = GET_SUBMISSIONS.output 
         .splitCsv(header:true) 
         .map { row -> tuple(row.submission_id, row.image_id) }
-    // UPDATE_SUBMISSION_STATUS_BEFORE_RUN(image_ch.map { tuple(it[0], "EVALUATION_IN_PROGRESS") })
-    // BUILD_SUBFOLDERS(image_ch.map { tuple(it[0], "build") }, params.project_name, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
-    // RUN_DOCKER(image_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, BUILD_SUBFOLDERS.output)
-    // UPDATE_SUBMISSION_STATUS_AFTER_RUN(RUN_DOCKER.output.map { tuple(it[0], "ACCEPTED") })
-    // VALIDATE(RUN_DOCKER.output, UPDATE_SUBMISSION_STATUS_AFTER_RUN.output, params.validation_script)
-    // UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE(VALIDATE.output.map { tuple(it[0], it[2]) })
-    // ANNOTATE_SUBMISSION_AFTER_VALIDATE(VALIDATE.output)
-    // SCORE(VALIDATE.output, UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE.output, ANNOTATE_SUBMISSION_AFTER_VALIDATE.output, params.scoring_script)
-    // UPDATE_SUBMISSION_STATUS_AFTER_SCORE(SCORE.output.map { tuple(it[0], it[2]) })
-    // ANNOTATE_SUBMISSION_AFTER_SCORE(SCORE.output)
-    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score, "ready")//, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+    UPDATE_SUBMISSION_STATUS_BEFORE_RUN(image_ch.map { tuple(it[0], "EVALUATION_IN_PROGRESS") })
+    BUILD_SUBFOLDERS(image_ch.map { tuple(it[0], "build") }, params.project_name, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
+    RUN_DOCKER(image_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, BUILD_SUBFOLDERS.output)
+    UPDATE_SUBMISSION_STATUS_AFTER_RUN(RUN_DOCKER.output.map { tuple(it[0], "ACCEPTED") })
+    VALIDATE(RUN_DOCKER.output, UPDATE_SUBMISSION_STATUS_AFTER_RUN.output, params.validation_script)
+    UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE(VALIDATE.output.map { tuple(it[0], it[2]) })
+    ANNOTATE_SUBMISSION_AFTER_VALIDATE(VALIDATE.output)
+    SCORE(VALIDATE.output, UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE.output, ANNOTATE_SUBMISSION_AFTER_VALIDATE.output, params.scoring_script)
+    UPDATE_SUBMISSION_STATUS_AFTER_SCORE(SCORE.output.map { tuple(it[0], it[2]) })
+    ANNOTATE_SUBMISSION_AFTER_SCORE(SCORE.output)
+    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
 }

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -8,7 +8,7 @@ params.project_name = "DPE-testing"
 params.view_id = "syn53475818"
 // Synapse ID for Input Data folder
 params.input_id = "syn51390589"
-// E-mail template ("no" to send e-mail without score update, "yes" to send an e-mail with)
+// E-mail template (case-sensitive. "no" to send e-mail without score update, "yes" to send an e-mail with)
 params.email_with_score = "No"
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
@@ -20,7 +20,7 @@ params.scoring_script = "score.py"
 params.validation_script = "validate.py"
 
 // Ensuring correct input parameter values
-assert params.email_with_score.toLowerCase() in ["yes", "no"], "Invalid value for ``email_with_score``. Can either be ''yes'' or ''no''."
+assert params.email_with_score in ["yes", "no"], "Invalid value for ``email_with_score``. Can either be ''yes'' or ''no''."
 
 // import modules
 include { SYNAPSE_STAGE } from '../modules/synapse_stage.nf'

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -9,7 +9,7 @@ params.view_id = "syn53475818"
 // Synapse ID for Input Data folder
 params.input_id = "syn51390589"
 // E-mail template (case-sensitive. "no" to send e-mail without score update, "yes" to send an e-mail with)
-params.email_with_score = "no"
+params.email_with_score = "yes"
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -9,7 +9,7 @@ params.view_id = "syn53475818"
 // Synapse ID for Input Data folder
 params.input_id = "syn51390589"
 // E-mail template ("no" to send e-mail without score update, "yes" to send an e-mail with)
-params.email_with_score = "no"
+params.email_with_score = "nooo"
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -19,6 +19,9 @@ params.scoring_script = "score.py"
 // Validation Script
 params.validation_script = "validate.py"
 
+// Ensuring correct input parameter values
+assert params.email_with_score.toLowerCase() in ["yes", "no"], "Invalid value for ``email_with_score``. Can either be ''yes'' or ''no''."
+
 // import modules
 include { SYNAPSE_STAGE } from '../modules/synapse_stage.nf'
 include { GET_SUBMISSIONS } from '../modules/get_submissions.nf'
@@ -40,15 +43,15 @@ workflow MODEL_TO_DATA {
     image_ch = GET_SUBMISSIONS.output 
         .splitCsv(header:true) 
         .map { row -> tuple(row.submission_id, row.image_id) }
-    UPDATE_SUBMISSION_STATUS_BEFORE_RUN(image_ch.map { tuple(it[0], "EVALUATION_IN_PROGRESS") })
-    BUILD_SUBFOLDERS(image_ch.map { tuple(it[0], "build") }, params.project_name, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
-    RUN_DOCKER(image_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, BUILD_SUBFOLDERS.output)
-    UPDATE_SUBMISSION_STATUS_AFTER_RUN(RUN_DOCKER.output.map { tuple(it[0], "ACCEPTED") })
-    VALIDATE(RUN_DOCKER.output, UPDATE_SUBMISSION_STATUS_AFTER_RUN.output, params.validation_script)
-    UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE(VALIDATE.output.map { tuple(it[0], it[2]) })
-    ANNOTATE_SUBMISSION_AFTER_VALIDATE(VALIDATE.output)
-    SCORE(VALIDATE.output, UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE.output, ANNOTATE_SUBMISSION_AFTER_VALIDATE.output, params.scoring_script)
-    UPDATE_SUBMISSION_STATUS_AFTER_SCORE(SCORE.output.map { tuple(it[0], it[2]) })
-    ANNOTATE_SUBMISSION_AFTER_SCORE(SCORE.output)
-    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+    // UPDATE_SUBMISSION_STATUS_BEFORE_RUN(image_ch.map { tuple(it[0], "EVALUATION_IN_PROGRESS") })
+    // BUILD_SUBFOLDERS(image_ch.map { tuple(it[0], "build") }, params.project_name, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
+    // RUN_DOCKER(image_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, BUILD_SUBFOLDERS.output)
+    // UPDATE_SUBMISSION_STATUS_AFTER_RUN(RUN_DOCKER.output.map { tuple(it[0], "ACCEPTED") })
+    // VALIDATE(RUN_DOCKER.output, UPDATE_SUBMISSION_STATUS_AFTER_RUN.output, params.validation_script)
+    // UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE(VALIDATE.output.map { tuple(it[0], it[2]) })
+    // ANNOTATE_SUBMISSION_AFTER_VALIDATE(VALIDATE.output)
+    // SCORE(VALIDATE.output, UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE.output, ANNOTATE_SUBMISSION_AFTER_VALIDATE.output, params.scoring_script)
+    // UPDATE_SUBMISSION_STATUS_AFTER_SCORE(SCORE.output.map { tuple(it[0], it[2]) })
+    // ANNOTATE_SUBMISSION_AFTER_SCORE(SCORE.output)
+    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score)//, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
 }

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -8,8 +8,8 @@ params.project_name = "DPE-testing"
 params.view_id = "syn53475818"
 // Synapse ID for Input Data folder
 params.input_id = "syn51390589"
-// E-mail template (0 to send e-mail without score update, 1 to send an e-mail with)
-params.email_with_score = 0
+// E-mail template ("no" to send e-mail without score update, "yes" to send an e-mail with)
+params.email_with_score = "no"
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -9,7 +9,7 @@ params.view_id = "syn53475818"
 // Synapse ID for Input Data folder
 params.input_id = "syn51390589"
 // E-mail template ("no" to send e-mail without score update, "yes" to send an e-mail with)
-params.email_with_score = "nooo"
+params.email_with_score = "No"
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -8,8 +8,8 @@ params.project_name = "DPE-testing"
 params.view_id = "syn53475818"
 // Synapse ID for Input Data folder
 params.input_id = "syn51390589"
-// E-mail template (use False to send e-mail without score update)
-params.email_with_score = True
+// E-mail template (0 to send e-mail without score update, 1 to send an e-mail with)
+params.email_with_score = 0
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -8,6 +8,8 @@ params.project_name = "DPE-testing"
 params.view_id = "syn53475818"
 // Synapse ID for Input Data folder
 params.input_id = "syn51390589"
+// E-mail template (use False to send e-mail without score update)
+params.email_with_score = True
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER
@@ -48,5 +50,5 @@ workflow MODEL_TO_DATA {
     SCORE(VALIDATE.output, UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE.output, ANNOTATE_SUBMISSION_AFTER_VALIDATE.output, params.scoring_script)
     UPDATE_SUBMISSION_STATUS_AFTER_SCORE(SCORE.output.map { tuple(it[0], it[2]) })
     ANNOTATE_SUBMISSION_AFTER_SCORE(SCORE.output)
-    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
 }

--- a/subworkflows/MODEL_TO_DATA.nf
+++ b/subworkflows/MODEL_TO_DATA.nf
@@ -53,5 +53,5 @@ workflow MODEL_TO_DATA {
     // SCORE(VALIDATE.output, UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE.output, ANNOTATE_SUBMISSION_AFTER_VALIDATE.output, params.scoring_script)
     // UPDATE_SUBMISSION_STATUS_AFTER_SCORE(SCORE.output.map { tuple(it[0], it[2]) })
     // ANNOTATE_SUBMISSION_AFTER_SCORE(SCORE.output)
-    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score)//, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score, "ready")//, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
 }


### PR DESCRIPTION
#### problem

The existing e-mail template needs to be updated, and the option to send an e-mail WITHOUT score updates / links to Submission views should be available to users.

#### solution

1. 4 e-mail templates are added. Two for successful evaluations, where one reports the score + a link to the Submission view, and one does not. Two for failed evaluations due to a validation error, where both report the validation error reason, and one shares a link to the Submission view but the other does not.
2. A new parameter gives users the option to choose one or the other: send e-mail updates revealing score values + Submission view links, OR send e-mail updates **without** revealing score values + Submission view links.

#### testing & preview

`tower-dev` run results: https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/38tOEHRhobMaFu

----

`params.email_with_score = "yes"`:

Successful evaluation:

<img width="475" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/d8589790-bfeb-4689-bafd-c4d6d3455310">

Failed evaluation due to validation error:

<img width="748" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/791cbfbf-ec7f-42e5-bffc-4adcd2081c86">

----

`params.email_with_score = no`:

Successful evaluation:

<img width="764" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/d20556e6-ba17-44de-ba15-1a910f442ebc">

Failed evaluation due to validation error:

<img width="337" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/514507cf-81bd-4ca8-b921-880ba9485220">

