### PR TITLE
[IBCDPE-827] Implements Email Notifications in `DATA_TO_MODEL_CHALLENGE` Workflow

### DIFF
--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -37,12 +37,12 @@ def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[s
 
 
 def get_score_dict(score):
-    strs = [""]
+    strings = [""]
     for key in score.keys():
-        str = f"{key} : {score[key][0]}" + "\n"
-        strs.append(str)
+        string = f"{key} : {score[key][0]}" + "\n"
+        strings.append(string)
 
-    return strs
+    return strings
 
 
 def email_template(

--- a/subworkflows/DATA_TO_MODEL.nf
+++ b/subworkflows/DATA_TO_MODEL.nf
@@ -10,6 +10,10 @@ params.scoring_script = "data_to_model_score.py"
 params.validation_script = "validate.py"
 // Testing Data
 params.testing_data = "syn53627077"
+// E-mail template (case-sensitive. "no" to send e-mail without score update, "yes" to send an e-mail with)
+params.email_with_score = "yes"
+// Ensuring correct input parameter values
+assert params.email_with_score in ["yes", "no"], "Invalid value for ``email_with_score``. Can either be ''yes'' or ''no''."
 
 // import modules
 include { SYNAPSE_STAGE } from '../modules/synapse_stage.nf'
@@ -22,6 +26,7 @@ include { VALIDATE } from '../modules/validate.nf'
 include { SCORE_DATA_TO_MODEL as SCORE } from '../modules/score_data_to_model.nf'
 include { ANNOTATE_SUBMISSION as ANNOTATE_SUBMISSION_AFTER_VALIDATE } from '../modules/annotate_submission.nf'
 include { ANNOTATE_SUBMISSION as ANNOTATE_SUBMISSION_AFTER_SCORE } from '../modules/annotate_submission.nf'
+include { SEND_EMAIL } from '../modules/send_email.nf'
 
 workflow DATA_TO_MODEL {
     SYNAPSE_STAGE(params.testing_data, "testing_data")
@@ -37,4 +42,6 @@ workflow DATA_TO_MODEL {
     SCORE(VALIDATE.output, SYNAPSE_STAGE.output, UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE.output, ANNOTATE_SUBMISSION_AFTER_VALIDATE.output, params.scoring_script)
     UPDATE_SUBMISSION_STATUS_AFTER_SCORE(SCORE.output.map { tuple(it[0], it[2]) })
     ANNOTATE_SUBMISSION_AFTER_SCORE(SCORE.output)
+    SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+
 }

--- a/subworkflows/DATA_TO_MODEL.nf
+++ b/subworkflows/DATA_TO_MODEL.nf
@@ -43,5 +43,4 @@ workflow DATA_TO_MODEL {
     UPDATE_SUBMISSION_STATUS_AFTER_SCORE(SCORE.output.map { tuple(it[0], it[2]) })
     ANNOTATE_SUBMISSION_AFTER_SCORE(SCORE.output)
     SEND_EMAIL(params.view_id, image_ch.map { it[0] }, params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
-
 }


### PR DESCRIPTION
**Description:**

When submissions are evaluated, submitters need to be able to receive feedback in a timely fashion. This was simple thanks to @jaymedina's earlier PRs (#4  & #7 ). 

**Notes:**
- I made some minor changes to `send_email.py` because the reserved Python keyword `str` was being overwritten in `get_score_dict`.

**Testing:** 
- This change was tested on Tower [here](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/dynamic-challenge-project/watch/3YlTwcBW6uDUMM).
- I have not been able to test this on the Dynamic Challenge submission view yet, but I will do so before merging to `main`.