### PR TITLE
[IBCDPE-841] New Dockerfile with docker and synapseclient py libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM ubuntu:22.04
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     bash \
     curl \
-    gpg
+    gpg \
+    python3 \
+    python3-pip
 
 #Add the official Docker (apt-get) repository
 RUN mkdir -p /etc/apt/keyrings
@@ -17,4 +19,9 @@ RUN echo \
 
 #install docker
 RUN apt-get update -y && apt-get install -y \
-    docker-ce 
+    docker-ce
+
+# Install Python libraries using pip
+RUN pip3 install \
+    docker \
+    synapseclient

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:22.04
 
+LABEL org.opencontainers.image.source=https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge
+
 #install apt-get dependencies
 RUN apt-get update -y && apt-get upgrade -y && apt-get install -y \
     bash \


### PR DESCRIPTION
#### problem

The `run_docker.nf` task was still using the outdated `nf-model2data` container and did not have all the dependencies necessary to run the new `run_docker.py` in https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/pull/12. 

#### solution

- [x] Update the `nf-synapse-challenge` Dockerfile with the necessary dependencies
- [x] Publish `nf-synapse-challenge` Docker image to the GitHub container registry to officially replace `nf-model2data`

#### testing

I pull the Docker image locally and call on the new dependencies to make sure the environment was built properly

<img width="969" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/e9a27a16-f0e9-4c3d-9c47-09c19f1e3097">
