### PR TITLE
[IBCPDE-853] Refactoring `run_docker.py` and `create_folders.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,16 +87,18 @@ flowchart LR;
     B[UPDATE STATUS]-->E;
     C[CREATE FOLDERS]-->E;
     E-->G[UPDATE STATUS];
-    G-->H[VALIDATE];
-    H-->I[ANNOTATE];
-    H-->J[UPDATE STATUS];
-    I-->K[SCORE];
-    J-->K;
-    K-->L[ANNOTATE];
-    K-->M[UPDATE STATUS];
-    L-->N;
-    M-->N[SEND EMAIL];
-    N-->O[END];
+    E-->H[UPDATE FOLDERS];
+    G-->I[VALIDATE];
+    H-->I;
+    I-->J[UPDATE STATUS];
+    I-->K[ANNOTATE];
+    J-->L[SCORE];
+    K-->L;
+    L-->M[UPDATE STATUS];
+    L-->N[ANNOTATE];
+    M-->O;
+    N-->O[SEND EMAIL];
+    O-->P[END];
 ```
 
 

--- a/bin/create_folders.py
+++ b/bin/create_folders.py
@@ -7,16 +7,12 @@ and ``run_docker.nf`` workflows. It provides the following functionality:
 - Modifies a File entity's filehandle name by prefixing it with a given string
 """
 
-from logging import root
-import os
 import sys
+from typing import List, Union
 
-import send_email
+import helpers
 
 import synapseclient
-import synapseutils
-
-from typing import List, Union
 
 
 def create_folder(
@@ -43,65 +39,6 @@ def create_folder(
     subfolder = syn.store(obj=subfolder)
 
     return subfolder
-
-
-def prefix_filename(
-    syn: synapseclient.Synapse, prefix_name: str, old_file_entity: synapseclient.File
-) -> None:
-    """
-    Prefixes the name of the old file entity with the desired ``prefix_name`` and updates the file name and metadata in Synapse.
-
-    Arguments:
-        syn: The Synapse Python client instance
-        prefix_name: The prefix to be added to your Synapse File name
-        old_file_entity: The old File entity to be updated
-
-    """
-    filename = old_file_entity.name
-    prefixed_filename = f"{prefix_name}_{filename}"
-
-    synapseutils.changeFileMetaData(
-        syn,
-        entity=old_file_entity,
-        downloadAs=prefixed_filename,
-        forceVersion=False,
-        name=prefixed_filename,
-    )
-
-
-def update_subfolders(
-    syn: synapseclient.Synapse,
-    folder_name: str,
-    input_file: str,
-    submitter_id: str,
-    parent_id: Union[str, synapseclient.Entity],
-) -> synapseclient.File:
-    """
-    Update subfolders based on the given predictions file, submitter ID, and parent ID, and returns the file entity.
-
-    Arguments:
-        syn: A Synapse Python client instance
-        folder_name: The name of the subfolder that will house the input_file
-        input_file: The name of the file to be uploaded into the subfolder
-        submitter_id: The ID of the submitter
-        parent_id: The ID of the parent folder
-
-    Returns:
-        The Synapse File entity that was created
-
-    """
-
-    submitter_folder = syn.findEntityId(submitter_id, parent_id)
-
-    subfolder = syn.findEntityId(folder_name, submitter_folder)
-
-    if not subfolder:
-        raise ValueError(
-            f"Could not find '{folder_name}' subfolder on Synapse for submitter ID: {submitter_id}"
-        )
-
-    file_entity = syn.store(synapseclient.File(input_file, parentId=subfolder))
-    return file_entity
 
 
 def update_permissions(
@@ -141,9 +78,6 @@ def update_permissions(
 def create_folders(
     project_name: str,
     submission_id: str,
-    create_or_update: str,
-    predictions_file: Union[None, str],
-    log_file: Union[None, str],
     syn: Union[None, synapseclient.Synapse] = None,
     subfolders: List[str] = ["docker_logs", "predictions"],
     only_admins: str = "predictions",
@@ -182,100 +116,41 @@ def create_folders(
 
     # Retrieving Synapse IDs that will be necessary later
     project_id = syn.findEntityId(name=project_name)
-    submitter_id = send_email.get_participant_id(syn, submission_id)[0]
+    submitter_id = helpers.get_participant_id(syn, submission_id)[0]
 
-    if create_or_update == "create":
-        # Create the Root-Folder/ directly under Project
-        root_folder = create_folder(
-            syn, folder_name=root_folder_name, parent=project_id
-        )
+    # Create the Root-Folder/ directly under Project
+    root_folder = create_folder(syn, folder_name=root_folder_name, parent=project_id)
 
-        # Creating the level 1 (directly under Root-Folder/) subfolder,
-        # which is named after the submitters' team/userIds.
-        level1_subfolder = create_folder(
-            syn, folder_name=submitter_id, parent=root_folder
+    # Creating the level 1 (directly under Root-Folder/) subfolder,
+    # which is named after the submitters' team/userIds.
+    level1_subfolder = create_folder(syn, folder_name=submitter_id, parent=root_folder)
+    update_permissions(
+        syn,
+        subfolder=level1_subfolder,
+        project_id=project_id,
+        principal_id=submitter_id,
+        access_type=["READ", "DOWNLOAD"],
+    )
+    # Creating the level 2 subfolders that live directly under submitter subfolder.
+    for level2_subfolder in subfolders:
+        level2_subfolder = create_folder(
+            syn, folder_name=level2_subfolder, parent=level1_subfolder
         )
-        update_permissions(
-            syn,
-            subfolder=level1_subfolder,
-            project_id=project_id,
-            principal_id=submitter_id,
-            access_type=["READ", "DOWNLOAD"],
-        )
-        # Creating the level 2 subfolders that live directly under submitter subfolder.
-        for level2_subfolder in subfolders:
-            level2_subfolder = create_folder(
-                syn, folder_name=level2_subfolder, parent=level1_subfolder
+        # The level 2 subfolders will inherit the permissions set on the level 1 subfolder above.
+        # The subfolder denoted under ``only_admins`` will have its own ACL, and will be only accessed by
+        # Project maintainers:
+        if level2_subfolder.name == only_admins:
+            update_permissions(
+                syn,
+                subfolder=level2_subfolder,
+                project_id=project_id,
+                principal_id=submitter_id,
+                access_type=[],
             )
-            # The level 2 subfolders will inherit the permissions set on the level 1 subfolder above.
-            # The subfolder denoted under ``only_admins`` will have its own ACL, and will be only accessed by
-            # Project maintainers:
-            if level2_subfolder.name == only_admins:
-                update_permissions(
-                    syn,
-                    subfolder=level2_subfolder,
-                    project_id=project_id,
-                    principal_id=submitter_id,
-                    access_type=[],
-                )
-
-    elif create_or_update == "update":
-        # Get the Synapse ID of the root Folder housing all the subfolders and File entities
-        root_folder_id = syn.findEntityId(name=root_folder_name, parent=project_id)
-        if not root_folder_id:
-            raise ValueError(
-                f"Could not find '{root_folder_name}' root folder on Synapse for project ID: {project_id}"
-            )
-        # Dictionary to store file entities and their corresponding folder names
-        file_entities = {}
-        for input_file, folder_name in (
-            (predictions_file, "predictions"),
-            (log_file, "docker_logs"),
-        ):
-            # ``input_file`` must not be None or empty to proceed
-            # with the upload to Synapse
-            if input_file and os.path.getsize(input_file) > 0:
-                file_entities[folder_name] = update_subfolders(
-                    syn,
-                    folder_name=folder_name,
-                    input_file=input_file,
-                    submitter_id=submitter_id,
-                    parent_id=root_folder_id,
-                )
-                # Prefix the filename with the submission ID
-                # after storing it in Synapse
-                if file_entities[folder_name]:
-                    prefix_filename(
-                        syn,
-                        prefix_name=submission_id,
-                        old_file_entity=file_entities[folder_name],
-                    )
-        if not any(file_entities.values()):
-            raise ValueError(
-                f"Non-empty prediction and/or log file(s) must be provided to update folders for submission {submission_id}. Exiting."
-            )
-
-    else:
-        raise ValueError(
-            "``create_or_update`` must be either 'create' or 'update'. Exiting."
-        )
 
 
 if __name__ == "__main__":
-
-    # Defining arguments
     project_name = sys.argv[1]
     submission_id = sys.argv[2]
-    create_or_update = sys.argv[3]
-    # TODO: https://sagebionetworks.jira.com/browse/ORCA-311
-    predictions_file = sys.argv[4] if len(sys.argv) >= 5 else None
-    log_file = sys.argv[5] if len(sys.argv) == 6 else None
 
-    # Create or update folders
-    create_folders(
-        project_name=project_name,
-        submission_id=submission_id,
-        create_or_update=create_or_update,
-        predictions_file=predictions_file,
-        log_file=log_file,
-    )
+    create_folders(project_name=project_name, submission_id=submission_id)

--- a/bin/create_folders.py
+++ b/bin/create_folders.py
@@ -10,9 +10,9 @@ and ``run_docker.nf`` workflows. It provides the following functionality:
 import sys
 from typing import List, Union
 
-import helpers
-
 import synapseclient
+
+import helpers
 
 
 def create_folder(

--- a/bin/dynamic_challenge_send_email.py
+++ b/bin/dynamic_challenge_send_email.py
@@ -9,8 +9,8 @@ import synapseclient
 
 from typing import Tuple
 
+from helpers import get_participant_id
 from send_email import (
-    get_participant_id,
     get_score_dict,
     get_annotations,
 )

--- a/bin/helpers.py
+++ b/bin/helpers.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
-import synapseclient
+import os
 from typing import List
+
+import synapseclient
+
 
 def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[str]:
     """
@@ -14,7 +17,8 @@ def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[s
       submission_id: The ID for an individual submission within an evaluation queue
 
     Returns:
-      Returns the synID of a team or individual participant
+      The synID of a team or individual participant
+
     """
     # Retrieve a Submission object
     submission = syn.getSubmission(submission_id, downloadFile=False)
@@ -25,3 +29,35 @@ def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[s
     # Ensure that the participant_id returned is a list
     # so it can be fed into syn.sendMessage(...) later.
     return [participant_id]
+
+
+def rename_file(submission_id: str, input_path: str) -> None:
+    """
+    Prefixes the name of a file with the given ``submission_id``.
+    E.g: Given ``submission_id``="123", the file ``path/to/file.txt`` is
+    renamed as ``path/to/123_file.txt``.
+
+    Arguments:
+        submission_id: The ID used to rename the file
+        input_path: The path of the file to be renamed
+
+    """
+    # Extract the directory from the input path
+    dirname = os.path.dirname(input_path)
+
+    # Extract the filename from the input path
+    filename = os.path.basename(input_path)
+
+    # Rename the file based on submission_id
+    new_filename = f"{submission_id}_{filename}"
+
+    # Create the new path for the renamed file
+    new_path = os.path.join(dirname, new_filename)
+
+    # Rename the original file
+    os.rename(input_path, new_path)
+
+    # Print the path to the renamed file
+    print("File renamed successfully.")
+    print("Original file: ", input_path)
+    print("Renamed file: ", new_path)

--- a/bin/helpers.py
+++ b/bin/helpers.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import synapseclient
+from typing import List
+
+def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[str]:
+    """
+    Retrieves the teamId of the participating team that made
+    the submission. If the submitter is an individual rather than
+    a team, the userId for the individual is retrieved.
+
+    Arguments:
+      syn: A Synapse Python client instance
+      submission_id: The ID for an individual submission within an evaluation queue
+
+    Returns:
+      Returns the synID of a team or individual participant
+    """
+    # Retrieve a Submission object
+    submission = syn.getSubmission(submission_id, downloadFile=False)
+
+    # Get the teamId or userId of submitter
+    participant_id = submission.get("teamId") or submission.get("userId")
+
+    # Ensure that the participant_id returned is a list
+    # so it can be fed into syn.sendMessage(...) later.
+    return [participant_id]

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+import helpers
 import synapseclient
 
 from typing import List, NamedTuple
@@ -10,30 +11,6 @@ class SubmissionAnnotations(NamedTuple):
     status: str
     score: List[int]
     reason: str
-
-
-def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[str]:
-    """
-    Retrieves the teamId of the participating team that made
-    the submission. If the submitter is an individual rather than
-    a team, the userId for the individual is retrieved.
-
-    Arguments:
-      syn: A Synapse Python client instance
-      submission_id: The ID for an individual submission within an evaluation queue
-
-    Returns:
-      Returns the synID of a team or individual participant
-    """
-    # Retrieve a Submission object
-    submission = syn.getSubmission(submission_id, downloadFile=False)
-
-    # Get the teamId or userId of submitter
-    participant_id = submission.get("teamId") or submission.get("userId")
-
-    # Ensure that the participant_id returned is a list
-    # so it can be fed into syn.sendMessage(...) later.
-    return [participant_id]
 
 
 def get_score_dict(score):
@@ -162,7 +139,7 @@ def send_email(view_id: str, submission_id: str, email_with_score: str):
     submission_annotations = get_annotations(syn, submission_id)
 
     # Get the Synapse users to send an e-mail to
-    ids_to_notify = get_participant_id(syn, submission_id)
+    ids_to_notify = helpers.get_participant_id(syn, submission_id)
 
     # Create the subject and body of the e-mail message, depending on submission status
     subject = (

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
 import sys
-import helpers
-import synapseclient
-
 from typing import List, NamedTuple
 
+import synapseclient
+
+import helpers
 
 class SubmissionAnnotations(NamedTuple):
     status: str

--- a/bin/update_folders.py
+++ b/bin/update_folders.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from typing import Union
+import synapseclient
+import helpers
+
+
+def store_file(
+    syn: synapseclient.Synapse,
+    folder_name: str,
+    input_file: str,
+    submitter_id: str,
+    parent_id: Union[str, synapseclient.Entity]
+) -> synapseclient.File:
+    """
+    Update subfolders based on the given predictions file, submitter ID, and parent ID, and returns the file entity.
+
+    Arguments:
+        syn: A Synapse Python client instance
+        folder_name: The name of the subfolder that will house the input_file
+        input_file: The name of the file to be uploaded into the subfolder
+        submitter_id: The ID of the submitter
+        parent_id: The ID of the parent folder
+
+    Returns:
+        The Synapse File entity that was created
+
+    """
+
+    submitter_folder = syn.findEntityId(submitter_id, parent_id)
+
+    subfolder = syn.findEntityId(folder_name, submitter_folder)
+
+    if not subfolder:
+        raise ValueError(
+            f"Could not find '{folder_name}' subfolder on Synapse for submitter ID: {submitter_id}"
+        )
+
+    file_entity = syn.store(synapseclient.File(input_file, parentId=subfolder))
+    return file_entity
+
+
+def update_folders(project_name, submission_id, folder_name, input_file, root_folder_name="Logs"):
+    # Log into the client 
+    syn = synapseclient.login(silent=True)
+
+    # Retrieving Synapse IDs that will be necessary later
+    project_id = syn.findEntityId(name=project_name)
+    submitter_id = helpers.get_participant_id(syn, submission_id)[0]
+
+    # Get the Synapse ID of the root Folder housing all the subfolders and File entities
+    root_folder_id = syn.findEntityId(name=root_folder_name, parent=project_id)
+    if not root_folder_id:
+        raise ValueError(
+            f"Could not find '{root_folder_name}' root folder on Synapse for project ID: {project_id}"
+        )
+
+    # ``input_file`` must not be None or empty to proceed
+    # with the upload to Synapse
+    if input_file and os.path.getsize(input_file) > 0:
+        store_file(
+            syn,
+            folder_name=folder_name,
+            input_file=input_file,
+            submitter_id=submitter_id,
+            parent_id=root_folder_id,
+        )
+
+    else:
+        raise ValueError(
+            f"Non-empty prediction and log files must be provided to update folders for submission {submission_id}. Exiting."
+        )
+
+
+if __name__ == "__main__":
+
+    project_name = sys.argv[1]
+    submission_id = sys.argv[2]
+    folder_name = sys.argv[3]
+    file_name = sys.argv[4]
+
+    update_folders(
+        project_name=project_name,
+        submission_id=submission_id,
+        folder_name=folder_name,
+        input_file=file_name
+    )

--- a/modules/run_docker.nf
+++ b/modules/run_docker.nf
@@ -11,17 +11,16 @@ process RUN_DOCKER {
     input:
     val submission_id
     path staged_path
-    val project_name
     val cpus
     val memory
     val ready
     val ready
 
     output:
-    tuple val(submission_id), path('output/predictions.{csv,zip}')
+    tuple val(submission_id), path('output/predictions.{csv,zip}'), path('output/*.log')
 
     script:
     """
-    run_docker.py '${project_name}' '${submission_id}'
+    run_docker.py '${submission_id}'
     """
 }

--- a/modules/run_docker.nf
+++ b/modules/run_docker.nf
@@ -17,7 +17,7 @@ process RUN_DOCKER {
     val ready
 
     output:
-    tuple val(submission_id), path('output/predictions.{csv,zip}'), path('output/*.log')
+    tuple val(submission_id), path('output/*predictions.{csv,zip}'), path('output/*.log')
 
     script:
     """

--- a/modules/update_folders.nf
+++ b/modules/update_folders.nf
@@ -1,0 +1,21 @@
+process UPDATE_FOLDERS {
+    tag "${submission_id}"
+    
+    secret "SYNAPSE_AUTH_TOKEN"
+    container "sagebionetworks/synapsepythonclient:v4.1.1"
+
+    input:
+    val submission_id
+    val project_name
+    path predictions_file
+    path docker_log_file
+
+    output:
+    val "ready"
+
+    script:
+    """
+    update_folders.py '${project_name}' '${submission_id}' 'predictions' '${predictions_file}'
+    update_folders.py '${project_name}' '${submission_id}' 'docker_logs' '${docker_log_file}'
+    """
+}

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -2,7 +2,7 @@
 // The tower space is PHI safe
 nextflow.enable.dsl = 2
 // Empty string default to avoid warning
-params.submissions = "9743264"
+params.submissions = ""
 // Project Name (case-sensitive)
 params.project_name = "DPE-testing"
 // Synapse ID for Submission View
@@ -47,7 +47,8 @@ workflow MODEL_TO_DATA {
     SYNAPSE_STAGE(params.input_id, "input")
     CREATE_FOLDERS(submission_ch, "create", params.project_name)
     UPDATE_SUBMISSION_STATUS_BEFORE_RUN(submission_ch, "EVALUATION_IN_PROGRESS")
-    RUN_DOCKER(submission_ch, SYNAPSE_STAGE.output, params.project_name, params.cpus, params.memory, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
+    RUN_DOCKER(submission_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
+    UPDATE_FOLDERS(submission_ch, params.project_name, RUN_DOCKER.output.map { it[1] }, RUN_DOCKER.output.map { it[2] })
     UPDATE_SUBMISSION_STATUS_AFTER_RUN(RUN_DOCKER.output.map { it[0] }, "ACCEPTED")
     VALIDATE(RUN_DOCKER.output, UPDATE_SUBMISSION_STATUS_AFTER_RUN.output, params.validation_script)
     UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE(submission_ch, VALIDATE.output.map { it[2] })

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -2,7 +2,7 @@
 // The tower space is PHI safe
 nextflow.enable.dsl = 2
 // Empty string default to avoid warning
-params.submissions = ""
+params.submissions = "9743264"
 // Project Name (case-sensitive)
 params.project_name = "DPE-testing"
 // Synapse ID for Submission View
@@ -30,7 +30,8 @@ params.email_script = "send_email.py"
 include { CREATE_SUBMISSION_CHANNEL } from '../subworkflows/create_submission_channel.nf'
 include { SYNAPSE_STAGE } from '../modules/synapse_stage.nf'
 include { UPDATE_SUBMISSION_STATUS as UPDATE_SUBMISSION_STATUS_BEFORE_RUN } from '../modules/update_submission_status.nf'
-include { CREATE_FOLDERS as CREATE_FOLDERS } from '../modules/create_folders.nf'
+include { CREATE_FOLDERS } from '../modules/create_folders.nf'
+include { UPDATE_FOLDERS } from '../modules/update_folders.nf'
 include { RUN_DOCKER } from '../modules/run_docker.nf'
 include { UPDATE_SUBMISSION_STATUS as UPDATE_SUBMISSION_STATUS_AFTER_RUN } from '../modules/update_submission_status.nf'
 include { UPDATE_SUBMISSION_STATUS as UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE } from '../modules/update_submission_status.nf'


### PR DESCRIPTION
### problem

The new `run_docker.py`, as it stands, performs functionality outside its scope, which is currently to run the submitted Docker container and prepare any relevant outputs for upload into Synapse in the tasks that follow. The current design principle for `nf-synapse-challenge` is to write each task (and any corresponding python script) with a clearly defined purpose, while also maintaining flexibility in order to allow it to be reused in other contexts (other workflows).

### solution

On a high level, refactoring is done on 2 scripts: 
1. `run_docker.py`
2. `create_folders.py`

Which ends up affecting:
1. `model_to_data.nf`
2. `run_docker.nf`
4. **`update_folders.nf`
5. `send_email.py`
6. **`helpers.py`
7. **`update_folders.py`

 ** = new scripts

In the model-to-data workflow, the `UPDATE_FOLDERS` task gets reintroduced:

```mermaid

flowchart LR;
    A[SYNAPSE STAGE]-->E[RUN DOCKER];
    B[UPDATE STATUS]-->E;
    C[CREATE FOLDERS]-->E;
    E-->G[UPDATE STATUS];
    E-->H{UPDATE FOLDERS};
    G-->I[VALIDATE];
    H-->I;
    I-->J[UPDATE STATUS];
    I-->K[ANNOTATE];
    J-->L[SCORE];
    K-->L;
    L-->M[UPDATE STATUS];
    L-->N[ANNOTATE];
    M-->O;
    N-->O[SEND EMAIL];
    O-->P[END];
```

On a low level, the refactoring relieves `RUN_DOCKER` of the responsibility to upload files directly to synapse and passes it onto `UPDATE_FOLDERS`:

```mermaid

sequenceDiagram
    participant A as CREATE_FOLDERS
    Note right of A: Creates folders on Synapse
    A->>B: passes "ready"
    participant B as RUN_DOCKER
	  Note right of B: Runs Docker container
	  Note right of B: Generates log & container outputs
	  Note right of B: (optional:) Renames container outputs
	  B->>C: passes container outputs
	  B->>C: passes docker execution logs
    participant C as UPDATE_FOLDERS
    Note right of C: Uploads container outputs
    Note right of C: Uploads docker execution logs
```
### testing & preview

Test run on [`tower-dev`](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2lbSs7fEovjOQP)

<img width="332" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/ca51d01e-24f0-45ba-ba3c-e6fa043d66db">
