### PR TITLE
[IBCPDE-847] Set an upper-limit to log file size

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ The workflow takes the following inputs:
 1. `validation_script` (optional): The string name of the validation script to use for the `VALIDATE` step of the workflow run. Defaults to `validate.py`
 1. `send_email` (optional): If `true`, sends an e-mail to the submitter on the status of their submission. Default is `true`.
 1. `email_script` (required if `send_email` is `true`): If `send_email` is `true`, choose an e-mail template to send to submitters on the status of their submission. Default is a generic `send_email.py` template.
-1. `only_admins` (optional & case-sensitive): Choose which folder(s), if any, should be set to private (i.e. only available to Challenge organizers). Must be a comma-separated string of folder names, e.g. "predictions,docker_logs"
+1. `private_folders` (optional & case-sensitive): Choose which folder(s), if any, should be set to private (i.e. only available to Challenge organizers). Must be a comma-separated string of folder names, e.g. "predictions,docker_logs"
+1. `log_max_size` (optional): The maximum size of the Docker execution log (in kilobytes). Defaults to 50 kb.
 
 Run the workflow locally with default inputs and a `submissions` string input:
 ```

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -295,6 +295,7 @@ def run_docker(
 
 if __name__ == "__main__":
     submission_id = sys.argv[1]
+    log_max_size = int(sys.argv[2])
     log_file_name = f"{submission_id}_docker.log"
 
-    run_docker(submission_id, log_file_name=log_file_name)
+    run_docker(submission_id, log_file_name=log_file_name, log_max_size=log_max_size)

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -141,7 +141,6 @@ def create_log_file(
         print(f"Original log message exceeds {log_max_size} Kb. Truncating...")
         log_text = log_text[-(log_max_size * 1000) :]
 
-    # Write the log message to the log file, using ``ascii`` encoding for legibility
     with open(
         os.path.join(log_file_path, log_file_name),
         "w",

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -128,13 +128,18 @@ def create_log_file(
     if log_file_path is None:
         log_file_path = os.getcwd()
 
-    if log_text is None:
-        log_text = "No Logs"
-    elif isinstance(log_text, bytes):
-        log_text = log_text.decode("utf-8")
+    # Get the size of the log text
+    log_text = log_text or "No Logs"
+    log_text_size = (
+        len(log_text)
+        if isinstance(log_text, bytes)
+        else len(str(log_text).encode("utf-8"))
+    )
 
-    # We need the size of the log message in bytes
-    log_text_size = len(log_text.encode("utf-8"))
+    # Decode the log text if it is bytes
+    log_text = (
+        log_text.decode("utf-8", "ignore") if isinstance(log_text, bytes) else log_text
+    )
 
     # Truncate the log message if it exceeds the maximum size
     if log_text_size > log_max_size * 1000:

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -145,7 +145,7 @@ def create_log_file(
     with open(
         os.path.join(log_file_path, log_file_name),
         "w",
-        encoding="ascii",
+        encoding="utf-8",
         errors="ignore",
     ) as log_file:
         log_file.write(log_text)

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -103,6 +103,62 @@ def handle_outputs(output_path: str, output_file_name: str, log_text: str):
     )
 
     return output_file, log_text
+def truncate_log_file(log_file_name: str,
+                      log_file_path: str,
+                      max_lines: int = 100) -> None:
+    """
+    Truncates the log file content to a maximum number of lines.
+
+    Args:
+        log_filename (str): The name of the log file to be truncated.
+        log_file_path (str): The path to the log file.
+        max_lines (int): The maximum number of lines to keep in the log file
+                         (default is 20).
+
+    """
+    # Construct the full path to the log file
+    log_file = os.path.join(log_file_path, log_file_name)
+
+    # Read the lines from the log file
+    with open(log_file, "r") as file:
+        lines = file.readlines()
+
+        # If the log file has more lines than the maximum, truncate it
+        if len(lines) > max_lines:
+            print("Truncating log file...")
+            with open(log_file, "w") as truncated_file:
+                # Write only the last max_lines lines to the log file
+                truncated_file.writelines(lines[-max_lines:])
+
+            # Print a message indicating that the log file has been truncated
+            print(f"Truncated log file {log_file} to a maximum of {max_lines} lines.")
+
+
+def get_last_lines(log_file_name, log_file_path, max_lines=100):
+    
+    lines = 0
+    
+    # Construct the full path to the log file
+    log_file = os.path.join(log_file_path, log_file_name)
+
+    with open(log_file, "rb") as f:
+        try:
+            f.seek(-2, os.SEEK_END)
+            # Keep reading, starting at the end, until n lines is read.
+            while lines < max_lines:
+                f.seek(-2, os.SEEK_CUR)
+                if f.read(1) == b"\n":
+                    lines += 1
+
+        except OSError:
+            # If file only contains one line, then only read that one
+            # line.  This exception will probably never occur, but
+            # adding it in, just in case.
+            f.seek(0)
+
+        last_lines = f.read().decode()
+
+    return last_lines
 
 
 def create_log_file(
@@ -241,10 +297,16 @@ def run_docker(
 
     # Capture any errors that may occur during the attempt to run the container
     except Exception as e:
+        # Reformat the error message
         log_text = str(e).replace("\\n", "\n")
+
+        # Create log file and store the log error message (``log_text``) inside
         create_log_file(
             log_file_name=log_file_name, log_file_path=output_path, log_text=log_text
         )
+
+        # Truncate the log file (if necessary)
+        truncate_log_file(log_file_name=log_file_name, log_file_path=output_path)
 
     # Handle any outputs from the container run in the ``output/`` directory.
     # This means: An expected output file, more than 1 output file, or no output file.
@@ -257,9 +319,11 @@ def run_docker(
         log_file_name=log_file_name, log_file_path=output_path, log_text=log_text
     )
 
+    # Truncate the log file (if necessary)
+    truncate_log_file(log_file_name=log_file_name, log_file_path=output_path)
+
     # Rename the predictions file if requested
-    if rename_output:
-        helpers.rename_file(submission_id, output_file)
+    if rename_output: helpers.rename_file(submission_id, output_file)
 
 
 if __name__ == "__main__":

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -119,9 +119,9 @@ def create_log_file(
 
     Arguments:
         log_file_name: The name of the log file to create
+        log_max_size: The maximum size of the log file in kilobytes
         log_file_path: The path where the log file will be created.
                        If not specified, the current working directory will be used.
-        log_max_size: The maximum size of the log file in kilobytes
         log_text: The text to write to the log file
 
     """

--- a/modules/run_docker.nf
+++ b/modules/run_docker.nf
@@ -13,6 +13,7 @@ process RUN_DOCKER {
     path staged_path
     val cpus
     val memory
+    val log_max_size
     val ready
     val ready
 
@@ -21,6 +22,6 @@ process RUN_DOCKER {
 
     script:
     """
-    run_docker.py '${submission_id}'
+    run_docker.py '${submission_id}' '${log_max_size}'
     """
 }

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -27,7 +27,7 @@ params.send_email = true
 params.email_script = "send_email.py"
 // The folder(s) below will be private (available only to admins)
 params.private_folders = "predictions"
-// Set the maximum size (in Kb) of the submitted Docker container's execution log file
+// Set the maximum size (in KB) of the submitted Docker container's execution log file
 params.log_max_size = "50"
 
 // import modules

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -27,6 +27,8 @@ params.send_email = true
 params.email_script = "send_email.py"
 // The folder(s) below will be private (available only to admins)
 params.private_folders = "predictions"
+// Set the maximum size (in Kb) of the submitted Docker container's execution log file
+params.log_max_size = "50"
 
 // import modules
 include { CREATE_SUBMISSION_CHANNEL } from '../subworkflows/create_submission_channel.nf'
@@ -49,7 +51,7 @@ workflow MODEL_TO_DATA {
     SYNAPSE_STAGE(params.input_id, "input")
     CREATE_FOLDERS(submission_ch, params.project_name, params.private_folders)
     UPDATE_SUBMISSION_STATUS_BEFORE_RUN(submission_ch, "EVALUATION_IN_PROGRESS")
-    RUN_DOCKER(submission_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
+    RUN_DOCKER(submission_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, params.log_max_size, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
     UPDATE_FOLDERS(submission_ch, params.project_name, RUN_DOCKER.output.map { it[1] }, RUN_DOCKER.output.map { it[2] })
     UPDATE_SUBMISSION_STATUS_AFTER_RUN(RUN_DOCKER.output.map { it[0] }, "ACCEPTED")
     VALIDATE(RUN_DOCKER.output, UPDATE_SUBMISSION_STATUS_AFTER_RUN.output, params.validation_script)


### PR DESCRIPTION
### problem
There is currently no upper-limit to how large a log file can get, which can cause download and upload bottlenecks when communicating with Synapse, and also be troublesome for organizers/participants who need to troubleshoot with the log file but are having to weed through unnecessary log information.

### solution
Set an upper-limit to how large a log file can get. I chose to set an upper limit based on the number of lines in the log file (`max_lines`) rather than the file size itself, because it's easier to visualize how long an error traceback can get in line number vs. byte size. An error traceback can vary in length, but usually contains the most relevant traceback information in the last ~20 lines (the current default), but this value can be experimented with using the `max_lines` argument.

### testing & preview

----
- [x] [Test](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3pePJuM4InhNvL) run for a submission with a standard output smaller than 50KB

Output message on Nextflow:

<img width="503" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/cefb9142-3f5d-4ca2-a3c9-c895e9a365a7">

Small stdout message; entire output is stored in log file:

<img width="1315" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/080f1b99-ca7b-4a5c-9958-089c398f0344">

----
- [x] [Test](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2SrfL7FyafStvr) run for a submission with a standard output larger than 50KB

Output message on Nextflow:

<img width="501" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/374cf63a-85aa-4bb2-bbd1-6ac78fa0edac">

The uploaded Docker execution log holds only the last 48.8 KB of the original Docker log message:

<img width="1325" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/a1e8a3bc-3834-4961-a601-c22412117c1f">

----
- [x] [Test](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/Ok76BYJAEhPdE) run for a submission with a standard output that has characters not supported by ASCII formatting

<img width="1306" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/3dc165e1-a35e-403c-b302-483f7ca1bd28">
