### PR TITLE
[IBCDPE-850] Allow users to choose which folder(s) remain private

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ The workflow requires the following inputs:
 1. `validation_script` (required): The string name of the validation script to use for the `VALIDATE` step of the workflow run. Defaults to `validate.py`
 1. `testing_data` (required): The Synapse ID for the folder holding the testing data for submissions.
 1. `email_with_score` (optional & case-sensitive): Choose whether or not the e-mail sent out to participants will include the evaluation score or not. Can either be "yes" or "no". Defaults to "yes".
+1. `send_email` (optional): If `true`, sends an e-mail to the submitter on the status of their submission. Default is `true`.
+1. `email_script` (required if `send_email` is `true`): If `send_email` is `true`, choose an e-mail template to send to submitters on the status of their submission. Default is a generic `send_email.py` template.
 
 
 Run the workflow locally with default inputs and a `submissions` string input:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ The workflow takes the following inputs:
 1. `memory` (optional): Amount of memory to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `16.GB`
 1. `scoring_script` (optional): The string name of the scoring script to use for the `SCORE` step of the workflow run. Defaults to `model_to_data_score.py`
 1. `validation_script` (optional): The string name of the validation script to use for the `VALIDATE` step of the workflow run. Defaults to `validate.py`
-
+1. `send_email` (optional): If `true`, sends an e-mail to the submitter on the status of their submission. Default is `true`.
+1. `email_script` (required if `send_email` is `true`): If `send_email` is `true`, choose an e-mail template to send to submitters on the status of their submission. Default is a generic `send_email.py` template.
+1. `only_admins` (optional): Choose which folder(s), if any, should be set to private (i.e. only available to Challenge organizers).
 
 Run the workflow locally with default inputs and a `submissions` string input:
 ```

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The workflow takes the following inputs:
 1. `validation_script` (optional): The string name of the validation script to use for the `VALIDATE` step of the workflow run. Defaults to `validate.py`
 1. `send_email` (optional): If `true`, sends an e-mail to the submitter on the status of their submission. Default is `true`.
 1. `email_script` (required if `send_email` is `true`): If `send_email` is `true`, choose an e-mail template to send to submitters on the status of their submission. Default is a generic `send_email.py` template.
-1. `only_admins` (optional): Choose which folder(s), if any, should be set to private (i.e. only available to Challenge organizers).
+1. `only_admins` (optional & case-sensitive): Choose which folder(s), if any, should be set to private (i.e. only available to Challenge organizers). Must be a comma-separated string of folder names, e.g. "predictions,docker_logs"
 
 Run the workflow locally with default inputs and a `submissions` string input:
 ```

--- a/bin/create_folders.py
+++ b/bin/create_folders.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     submission_id = sys.argv[2]
     only_admins = sys.argv[3]
 
-    # Remove whitespace and split by comma to get a list
+    # Remove whitespace (if any) and split by comma to get a list
     # of folders that should only be available to Challenge admins
     only_admins = only_admins.strip(" ").split(",")
 

--- a/bin/create_folders.py
+++ b/bin/create_folders.py
@@ -80,7 +80,7 @@ def create_folders(
     submission_id: str,
     syn: Union[None, synapseclient.Synapse] = None,
     subfolders: List[str] = ["docker_logs", "predictions"],
-    only_admins: List[str] = ["predictions"],
+    private_folders: List[str] = ["predictions"],
     root_folder_name: str = "Logs",
 ) -> None:
     """
@@ -105,7 +105,7 @@ def create_folders(
         log_file: The name of the log file that the docker_logs folder should be
                   updated with.
         subfolders: The subfolders to be created under the parent folder.
-        only_admins: The name of the subfolder that will have local share settings
+        private_folders: The name of the subfolder that will have local share settings
                      differing from the other subfolders.
         root_folder_name: The name of the root folder under the Project. Default is ''Logs''.
 
@@ -137,9 +137,9 @@ def create_folders(
             syn, folder_name=level2_subfolder, parent=level1_subfolder
         )
         # The level 2 subfolders will inherit the permissions set on the level 1 subfolder above.
-        # The subfolder denoted under ``only_admins`` will have its own ACL, and will be only accessed by
+        # The subfolder denoted under ``private_folders`` will have its own ACL, and will be only accessed by
         # Project maintainers:
-        if level2_subfolder.name in only_admins:
+        if level2_subfolder.name in private_folders:
             update_permissions(
                 syn,
                 subfolder=level2_subfolder,
@@ -153,11 +153,11 @@ if __name__ == "__main__":
     # Assigning variables to the command line args
     project_name = sys.argv[1]
     submission_id = sys.argv[2]
-    only_admins = sys.argv[3]
+    private_folders = sys.argv[3]
 
     # Remove whitespace (if any) and split by comma to get a list
     # of folders that should only be available to Challenge admins
-    only_admins = only_admins.strip(" ").split(",")
+    private_folders = private_folders.strip().split(",")
 
     # Create the folders
-    create_folders(project_name=project_name, submission_id=submission_id, only_admins=only_admins)
+    create_folders(project_name=project_name, submission_id=submission_id, private_folders=private_folders)

--- a/bin/create_folders.py
+++ b/bin/create_folders.py
@@ -152,5 +152,6 @@ def create_folders(
 if __name__ == "__main__":
     project_name = sys.argv[1]
     submission_id = sys.argv[2]
+    only_admins = sys.argv[3]
 
-    create_folders(project_name=project_name, submission_id=submission_id)
+    create_folders(project_name=project_name, submission_id=submission_id, only_admins=only_admins)

--- a/bin/create_folders.py
+++ b/bin/create_folders.py
@@ -80,7 +80,7 @@ def create_folders(
     submission_id: str,
     syn: Union[None, synapseclient.Synapse] = None,
     subfolders: List[str] = ["docker_logs", "predictions"],
-    only_admins: str = "predictions",
+    only_admins: List[str] = ["predictions"],
     root_folder_name: str = "Logs",
 ) -> None:
     """
@@ -139,7 +139,7 @@ def create_folders(
         # The level 2 subfolders will inherit the permissions set on the level 1 subfolder above.
         # The subfolder denoted under ``only_admins`` will have its own ACL, and will be only accessed by
         # Project maintainers:
-        if level2_subfolder.name == only_admins:
+        if level2_subfolder.name in only_admins:
             update_permissions(
                 syn,
                 subfolder=level2_subfolder,
@@ -150,8 +150,14 @@ def create_folders(
 
 
 if __name__ == "__main__":
+    # Assigning variables to the command line args
     project_name = sys.argv[1]
     submission_id = sys.argv[2]
     only_admins = sys.argv[3]
 
+    # Remove whitespace and split by comma to get a list
+    # of folders that should only be available to Challenge admins
+    only_admins = only_admins.strip(" ").split(",")
+
+    # Create the folders
     create_folders(project_name=project_name, submission_id=submission_id, only_admins=only_admins)

--- a/modules/create_folders.nf
+++ b/modules/create_folders.nf
@@ -12,13 +12,13 @@ process CREATE_FOLDERS {
     input:
     val submission_id
     val project_name
-    val only_admins
+    val private_folders
 
     output:
     val "ready"
 
     script:
     """
-    create_folders.py '${project_name}' '${submission_id}' '${only_admins}'
+    create_folders.py '${project_name}' '${submission_id}' '${private_folders}'
     """
 }

--- a/modules/create_folders.nf
+++ b/modules/create_folders.nf
@@ -11,14 +11,14 @@ process CREATE_FOLDERS {
 
     input:
     val submission_id
-    val create_or_update
     val project_name
+    val only_admins
 
     output:
     val "ready"
 
     script:
     """
-    create_folders.py '${project_name}' '${submission_id}' '${create_or_update}'
+    create_folders.py '${project_name}' '${submission_id}' '${only_admins}'
     """
 }

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -21,10 +21,12 @@ params.scoring_script = "model_to_data_score.py"
 params.validation_script = "validate.py"
 // Ensuring correct input parameter values
 assert params.email_with_score in ["yes", "no"], "Invalid value for ``email_with_score``. Can either be ''yes'' or ''no''."
-// toggle email notification
+// Toggle email notification
 params.send_email = true
-// set email script
+// Set email script
 params.email_script = "send_email.py"
+// The folder below will be private (available only to admins)
+params.only_admins = "predictions"
 
 // import modules
 include { CREATE_SUBMISSION_CHANNEL } from '../subworkflows/create_submission_channel.nf'
@@ -45,7 +47,7 @@ include { SEND_EMAIL } from '../modules/send_email.nf'
 workflow MODEL_TO_DATA {
     submission_ch = CREATE_SUBMISSION_CHANNEL()
     SYNAPSE_STAGE(params.input_id, "input")
-    CREATE_FOLDERS(submission_ch, "create", params.project_name)
+    CREATE_FOLDERS(submission_ch, params.project_name, params.only_admins)
     UPDATE_SUBMISSION_STATUS_BEFORE_RUN(submission_ch, "EVALUATION_IN_PROGRESS")
     RUN_DOCKER(submission_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
     UPDATE_FOLDERS(submission_ch, params.project_name, RUN_DOCKER.output.map { it[1] }, RUN_DOCKER.output.map { it[2] })

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -25,8 +25,8 @@ assert params.email_with_score in ["yes", "no"], "Invalid value for ``email_with
 params.send_email = true
 // Set email script
 params.email_script = "send_email.py"
-// The folder below will be private (available only to admins)
-params.only_admins = "predictions"
+// The folder(s) below will be private (available only to admins)
+params.only_admins = "docker_logs,predictions"
 
 // import modules
 include { CREATE_SUBMISSION_CHANNEL } from '../subworkflows/create_submission_channel.nf'

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -11,6 +11,8 @@ params.view_id = "syn53770151"
 params.input_id = "syn51390589"
 // E-mail template (case-sensitive. "no" to send e-mail without score update, "yes" to send an e-mail with)
 params.email_with_score = "yes"
+// Ensuring correct input parameter values
+assert params.email_with_score in ["yes", "no"], "Invalid value for ``email_with_score``. Can either be ''yes'' or ''no''."
 // Default CPUs to dedicate to RUN_DOCKER
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER
@@ -19,14 +21,12 @@ params.memory = "16.GB"
 params.scoring_script = "model_to_data_score.py"
 // Validation Script
 params.validation_script = "validate.py"
-// Ensuring correct input parameter values
-assert params.email_with_score in ["yes", "no"], "Invalid value for ``email_with_score``. Can either be ''yes'' or ''no''."
 // Toggle email notification
 params.send_email = true
 // Set email script
 params.email_script = "send_email.py"
 // The folder(s) below will be private (available only to admins)
-params.only_admins = "docker_logs,predictions"
+params.only_admins = "predictions"
 
 // import modules
 include { CREATE_SUBMISSION_CHANNEL } from '../subworkflows/create_submission_channel.nf'

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -26,7 +26,7 @@ params.send_email = true
 // Set email script
 params.email_script = "send_email.py"
 // The folder(s) below will be private (available only to admins)
-params.only_admins = "predictions"
+params.private_folders = "predictions"
 
 // import modules
 include { CREATE_SUBMISSION_CHANNEL } from '../subworkflows/create_submission_channel.nf'
@@ -47,7 +47,7 @@ include { SEND_EMAIL } from '../modules/send_email.nf'
 workflow MODEL_TO_DATA {
     submission_ch = CREATE_SUBMISSION_CHANNEL()
     SYNAPSE_STAGE(params.input_id, "input")
-    CREATE_FOLDERS(submission_ch, params.project_name, params.only_admins)
+    CREATE_FOLDERS(submission_ch, params.project_name, params.private_folders)
     UPDATE_SUBMISSION_STATUS_BEFORE_RUN(submission_ch, "EVALUATION_IN_PROGRESS")
     RUN_DOCKER(submission_ch, SYNAPSE_STAGE.output, params.cpus, params.memory, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
     UPDATE_FOLDERS(submission_ch, params.project_name, RUN_DOCKER.output.map { it[1] }, RUN_DOCKER.output.map { it[2] })


### PR DESCRIPTION
### problem

In conversations with CNB, it sounds like the folders that will remain private (i.e. available only to the Challenge organizers) are chosen on a case-by-case basis. There is currently an argument in `create_folders.py` that gives the user the option to choose which folder is set to private (`only_admins`), but this argument is not exposed to the Challenge organizer (i.e. not exposed in the workflow scripts).

### solution

- [x] Expose the `only_admins` argument to the Challenge organizer so it can be more easily modifiable.
- [x] Allow `only_admins` to be a list of folder names, not just 1 folder.
- [x] Update documentation accordingly with new parameter for `MODEL_TO_DATA`

### testing & preview

_I won't be testing on `DATA_TO_MODEL` since the only bin script affected is _`create_folders.py`_, which that workflow does not use._

- [x] [Test](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2bo6Tkz5pySu1O) on `MODEL_TO_DATA`

The resulting subfolders are here: https://www.synapse.org/#!Synapse:syn55199906
which you can view the local share settings for and see how it differs from the parent folder. Share settings for both subfolders are granted to only the Challenge Project admins, and not the submitter (`jenny.medina`)