### PR TITLE
[IBCDPE-918] Introduce arg flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,13 @@ If you are new to containerization, [see here](https://docs.github.com/en/packag
 > ```
 > [interpreter] [script_name] -p [predictions_file] -g [gold_standard_folder] -o [output_file]
 > ```
-> Example:
+> Python Example:
 > ```
-> python3 validate.py -p predictions.csv -g gold_standard_folder/ -o results.json
+> python3 validate.py -p "predictions.csv" -g "gold_standard_folder/" -o "results.json"
+> ```
+> R Example:
+> ```
+> Rscript validate.R -p "predictions.csv" -g "gold_standard_folder/" -o "results.json"
 > ```
 > Ensure that your scripts can be called in this way without issue.
 

--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ If you are new to containerization, [see here](https://docs.github.com/en/packag
 > [!warning]
 > Before modifying the input parameters, there are some things to consider...
 > * You must provide one of `submissions` or `manifest`. If you provide both, `submissions` will take precedence. Generally, `submissions` should be used for testing and `manifest` for automation.
-> * Your input scoring and validation scripts should be named `score.py` and `validate.py`, respectively, and will be called upon in the following format:
+> * Your input scoring and validation scripts should each take in 3 arguments: the predictions file, the gold standard file, and the output file name. The scripts will be called upon in the following format:
 > ```
-> [python_script_name] [predictions_file] [gold_standard_file] [output_file]`
+> [interpreter] [script_name] -p [predictions_file] -g [gold_standard_folder] -o [output_file]
 > ```
 > Example:
 > ```
-> validate.py predictions.csv gold_standard_validate.csv results.json
+> python3 validate.py -p predictions.csv -g gold_standard_folder/ -o results.json
 > ```
-> Ensure that your script can be called in this way without issue.
+> Ensure that your scripts can be called in this way without issue.
 
 ### Running the workflow
 

--- a/modules/score_model_to_data.nf
+++ b/modules/score_model_to_data.nf
@@ -17,6 +17,6 @@ process SCORE_MODEL_TO_DATA {
 
     script:
     """
-    status=\$(${execute_scoring} '${predictions}' '${goldstandard}' '${results}')
+    status=\$(${execute_scoring} -p '${predictions}' -g '${goldstandard}' -o '${results}')
     """
 }

--- a/modules/validate_model_to_data.nf
+++ b/modules/validate_model_to_data.nf
@@ -17,6 +17,6 @@ process VALIDATE {
 
     script:
     """
-    status=\$(${execute_validation} '${predictions}' '${goldstandard}' 'results.json')
+    status=\$(${execute_validation} -p '${predictions}' -g '${goldstandard}' -o 'results.json')
     """
 }


### PR DESCRIPTION
### problem

The val/score templates [use argparse](https://github.com/Sage-Bionetworks-Challenges/pegs-evaluation/blob/98aaa2aea9776ed02ae230293e954c549bf8e6e8/validate.py#L24) for arguments that are called in script execution. This isn't accounted for in the current way scripts are executed in model2data's `SCORE` and `VALIDATE`.

### solution

- [x] Introduce flags to `SCORE` and `VALIDATE`
- [x] Update `README.md`