### PR TITLE
[ORCA-204] Implement Docker submission execution timeout

### DIFF
--- a/modules/run_docker.nf
+++ b/modules/run_docker.nf
@@ -1,7 +1,7 @@
 // runs docker containers
 process RUN_DOCKER {
     tag "${submission_id}"
-    
+
     secret "SYNAPSE_AUTH_TOKEN"
     cpus "${cpus}"
     memory "${memory}"
@@ -10,6 +10,8 @@ process RUN_DOCKER {
 
     input:
     val submission_id
+    val container_timeout
+    val poll_interval
     path staged_path
     val cpus
     val memory
@@ -22,6 +24,6 @@ process RUN_DOCKER {
 
     script:
     """
-    run_docker.py '${submission_id}' '${log_max_size}'
+    run_docker.py '${submission_id}' '${container_timeout}' '${poll_interval}' '${log_max_size}'
     """
 }

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -19,6 +19,10 @@ assert params.email_with_score in ["yes", "no"], "Invalid value for ``email_with
 params.cpus = "4"
 // Default Memory to dedicate to RUN_DOCKER
 params.memory = "16.GB"
+// Maximum time (in minutes) to wait for Docker submission container run to complete
+params.container_timeout = "180"
+// Time (in minutes) between status checks during container monitoring
+params.poll_interval = "10"
 // The container that houses the scoring and validation scripts
 params.challenge_container = "ghcr.io/jaymedina/test_model2data:latest"
 // The command used to execute the Challenge scoring script in the base directory of the challenge_container: e.g. `python3 path/to/score.py`
@@ -57,7 +61,7 @@ workflow MODEL_TO_DATA {
     SYNAPSE_STAGE_GOLDSTANDARD(params.goldstandard_id, "goldstandard_${params.goldstandard_id}")
     CREATE_FOLDERS(submission_ch, params.project_name, params.private_folders)
     UPDATE_SUBMISSION_STATUS_BEFORE_RUN(submission_ch, "EVALUATION_IN_PROGRESS")
-    RUN_DOCKER(submission_ch, SYNAPSE_STAGE_DATA.output, params.cpus, params.memory, params.log_max_size, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
+    RUN_DOCKER(submission_ch, params.container_timeout, params.poll_interval, SYNAPSE_STAGE_DATA.output, params.cpus, params.memory, params.log_max_size, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
     UPDATE_FOLDERS(submission_ch, params.project_name, RUN_DOCKER.output.map { it[1] }, RUN_DOCKER.output.map { it[2] })
     UPDATE_SUBMISSION_STATUS_AFTER_RUN(RUN_DOCKER.output.map { it[0] }, "ACCEPTED")
     VALIDATE(RUN_DOCKER.output, SYNAPSE_STAGE_GOLDSTANDARD.output, UPDATE_SUBMISSION_STATUS_AFTER_RUN.output, params.execute_validation)


### PR DESCRIPTION
### problem

The Docker container submissions run without a time limit, leaving the pipeline vulnerable to hanging executions that could incur unnecessary costs.

### solution

- [x] New params `container_timeout` and `poll_interval` are introduced allowing users to set an upper limit for how long a container should run before it times out, and how long to wait between polling the container for status update
- [x] New function `monitor_container` is introduced for monitoring the elapsed time during a container execution, and shutting it down when necessary
- [x] A new error message `timeout_msg` is generated from `monitor_container` if a container times out, and is propagated thru the pipeline so it reaches the user
- [x] Documentation is updated reflecting new params

### testing & preview

- [x] [Test 1](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3Nig3AuizU48n2): Container runs for 2 mins, but `container_timeout` is 1 min

<img width="764" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/1807b537-1647-47a1-bdb0-ac15b914adec">

- [x] [Test 2](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2RAltzyiXYLOj5): Container runs for 2 mins, but `container_timeout` is 5 min

<img width="499" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/bcbb442e-4dfa-4c94-b2c5-c23aafcc9bea">

- [x] [Test 3](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/1CmScTlafYAqDG): Testing with multiple submissions of various execution times (2, 4, 5, 10 minutes), but `container_timeout` is 5 min. Ensure that the 1 and 4 minute submissions make it thru.

The expected evaluations (-55 and -56) failed

<img width="400" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/837e9afe-53fc-4057-94b3-23107cfbb97f">

- [x] [Test 4](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/1iqzPmtQtWjQ32): Multiple submissions (2, 2, 4, 5, 5, 5, 10 minutes), but `container_timeout` is 4 minutes. Only 2 submissions should pass.

As expected, only 9744479 and 9744460 pass:

<img width="386" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/b11957ef-5e3f-4ba0-b5d4-c84145bf087c">

Docker log example for a failed execution:

<img width="543" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/a6876954-59fe-496a-9fbf-1d842ae44f45">

Annotations:

<img width="393" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/e852bee2-a75f-4c8b-8496-f6e571af8fd8">

----
Remaining questions/comments:
* Users should be notified that there is a max to the amt of time their container can run for. this should be in the participant documentation somewhere. notify verena & gaia
* It would be unfortunate to make a submission, wait X hours, and then get a notification from the organizer that the submission never went thru. how can we notify users that their submissions are taking suspiciously long? is that our responsibility to begin with?