### PR TITLE
[IBCDPE-918] Add Challenge organizer contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ Example:
 
 The `MODEL_TO_DATA.nf` workflow works with all model-to-data medical Challenges hosted at Sage, but its parameters need to be customized in order to work with your particular Challenge. Please use the following steps to get started:
 
-1. Complete the pre-requesites listed under [Prerequisites](#prerequisites).
-2. Create a pull request with your Challenge profile added to `nextflow.config` (see [Configuring the Workflow](#configuring-the-workflow) for further instructions).
+1. Complete the pre-requesites listed under [Prerequisites for Model to Data](#Prerequisites-for-Model-to-Data).
+2. Create a pull request with your Challenge profile added to `nextflow.config` (see [Configuring the Model to Data Workflow](#Configuring-the-Model-to-Data-workflow) for further instructions).
 3. The maintainers of this repository will work with you to ensure your container is integrated with the model-to-data workflow and the parameters provided in step 2 are valid.
 4. Test the profile by making a submission to the evaluation queue represented by the given `params.view_id`. The reviewer will manually run the model-to-data workflow to ensure this new submission is picked up and processed appropriately.
 5. If the workflow is successful, the pull request can be merged and automation will be configured in the backend.
- 
+
 ### Introduction
 
-The `MODEL_TO_DATA.nf` workflow is designed to handle model-to-data Challenge formats by asynchronously running containers for Docker image submissions, evaluating the results using the provided scoring and validation scripts, updating the Synapse project with output files, and sharing the evaluation results with users via e-mail and submissions annotations. This repository can work in conjunction with [orca-recipes](https://github.com/Sage-Bionetworks-Workflows/orca-recipes) to enable scheduled workflow execution according to your desired cadence. Please see below for a DAG outlining the processes executed in the `MODEL_TO_DATA.nf` workflow, pre-requisites for running the workflow, and how you can tailor this workflow to your specific model-to-data Challenge requirements using by adding your own config profile(s) in `nextflow.config`.
+The `MODEL_TO_DATA.nf` workflow is designed to handle model-to-data Challenge formats by asynchronously running containers for Docker image submissions, evaluating the results using the provided scoring and validation scripts, updating the Synapse project with output files, and sharing the evaluation results with users via e-mail and submissions annotations. This repository can work in conjunction with [orca-recipes](https://github.com/Sage-Bionetworks-Workflows/orca-recipes) to enable scheduled workflow execution according to your desired cadence. Please see below for a DAG outlining the processes executed in the `MODEL_TO_DATA.nf` workflow, pre-requisites for running the workflow, and how you can tailor this workflow to your specific model-to-data Challenge requirements by adding your own config profile(s) in `nextflow.config`.
 
 ### Workflow DAG
 
@@ -77,7 +77,7 @@ flowchart LR;
     O-->P[END];
 ```
 
-### Prerequisites
+### Prerequisites for Model to Data
 
 In order to use this workflow, you must already have completed the following steps:
 
@@ -92,7 +92,7 @@ In order to use this workflow, you must already have completed the following ste
 
 If you are new to containerization and/or the GHCR, [see here](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry) for how to create and publish your own container on the GHCR.
 
-### Configuring the workflow
+### Configuring the Model to Data workflow
 
 Before the model-to-data workflow can run, it must be configured for a given Challenge. Challenge organizers are required to update the `nextflow.config` file with a config profile for their custom parameters to be picked up in the workflow run. [See here](https://www.nextflow.io/docs/latest/config.html#config-profiles) for more information on Nextflow config profiles and their uses. The requested profile should use the following format:
 
@@ -105,24 +105,7 @@ my_challenge {
   }
 ```
 
-Where the parameters are denoted by `params.[parameter_name]`. Below is the list of available parameters for configuring the `MODEL_TO_DATA.nf` workflow to a particular model-to-data Challenge. Keep in mind that most are optional, but some are required, and the workflow will not be able to run until they are provided:
-
-1. `submissions` (required if `manifest` is not provided): A comma separated list of submission IDs to evaluate.
-1. `manifest` (required if `submissions` is not provided): A path to a submission manifest containing submissions IDs to evaluate.
-1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in. Please replace placeholder value.
-1. `view_id` (required): The Synapse ID for your submission view. Please replace placeholder value.
-1. `data_folder_id` (required): The Synapse ID for the folder holding the testing or validation data for submissions. Please replace placeholder value.
-1. `goldstandard_id` (required): The Synapse ID for the gold standard file that will be used for evaluating the submissions. Please replace placeholder value.
-1. `email_with_score` (optional & case-sensitive): Choose whether or not the e-mail sent out to participants will include the evaluation score or not. Can either be "yes" or "no". Defaults to "yes".
-1. `cpus` (optional): Number of CPUs to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `4`.
-1. `memory` (optional): Amount of memory to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `16.GB`.
-1. `challenge_container` (optional): The name of the container that the scoring and validation scripts are housed in, and will be executed in, during the validation and scoring steps of the workflow. Defaults to `ghcr.io/jaymedina/test_model2data:latest`.
-1. `execute_scoring` (optional): This string should be `[interpreter] [path to script]` e.g. `python3 path/to/score.py`. This is the command that will be used to execute the scoring script for the `SCORE` step of the workflow run (without the arguments, which are appended later). Keep in mind this will execute at the base of your repository, so if the file is in the base directory, just use the file name. Defaults to `python3 /usr/local/bin/score.py`.
-1. `execute_validation` (optional): This string should be `[interpreter] [path to script]` e.g. `python3 path/to/validate.py`. This is the command that will be used to execute the validation script for the `VALIDATE` step of the workflow run (without the arguments, which are appended later). Keep in mind this will execute at the base of your repository, so if the file is in the base directory, just use the file name. Defaults to `python3 /usr/local/bin/validate.py`.
-1. `send_email` (optional): If `true`, sends an e-mail to the submitter on the status of their submission. Default is `true`.
-1. `email_script` (required if `send_email` is `true`): If `send_email` is `true`, choose an e-mail template to send to submitters on the status of their submission. Default is a generic `send_email.py` template.
-1. `private_folders` (optional & case-sensitive): Choose which folder(s), if any, should be set to private (i.e. only available to Challenge organizers). Must be a comma-separated string of folder names, e.g. "predictions,docker_logs".
-1. `log_max_size` (optional): The maximum size of the Docker execution log (in kilobytes). Defaults to 50 kb.
+Where the parameters are denoted by `params.[parameter_name]`. Below is the list of available parameters for configuring the `MODEL_TO_DATA.nf` workflow to a particular model-to-data Challenge. Keep in mind that most are optional, but some are required, and the workflow will not be able to run until they are provided.
 
 > [!warning]
 > Before modifying the input parameters, there are some things to consider...
@@ -141,6 +124,23 @@ Where the parameters are denoted by `params.[parameter_name]`. Below is the list
 > ```
 > Ensure that your scripts can be called in this way without issue.
 
+1. `submissions` (required if `manifest` is not provided): A comma separated list of submission IDs to evaluate.
+1. `manifest` (required if `submissions` is not provided): A path to a submission manifest containing submissions IDs to evaluate.
+1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in. Please replace placeholder value.
+1. `view_id` (required): The Synapse ID for your submission view. Please replace placeholder value.
+1. `data_folder_id` (required): The Synapse ID for the folder holding the testing or validation data for submissions. Please replace placeholder value.
+1. `goldstandard_id` (required): The Synapse ID for the gold standard file that will be used for evaluating the submissions. Please replace placeholder value.
+1. `email_with_score` (optional & case-sensitive): Choose whether or not the e-mail sent out to participants will include the evaluation score or not. Can either be "yes" or "no". Defaults to "yes".
+1. `cpus` (optional): Number of CPUs to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `4`.
+1. `memory` (optional): Amount of memory to dedicate to the `RUN_DOCKER` process i.e. the challenge executions. Defaults to `16.GB`.
+1. `challenge_container` (optional): The name of the container that the scoring and validation scripts are housed in, and will be executed in, during the validation and scoring steps of the workflow. Defaults to `ghcr.io/jaymedina/test_model2data:latest`.
+1. `execute_scoring` (optional): This string should be `[interpreter] [path to script]` e.g. `python3 path/to/score.py`. This is the command that will be used to execute the scoring script for the `SCORE` step of the workflow run (without the arguments, which are appended later). Keep in mind this will execute at the base of your repository, so if the file is in the base directory, just use the file name. Defaults to `python3 /usr/local/bin/score.py`.
+1. `execute_validation` (optional): This string should be `[interpreter] [path to script]` e.g. `python3 path/to/validate.py`. This is the command that will be used to execute the validation script for the `VALIDATE` step of the workflow run (without the arguments, which are appended later). Keep in mind this will execute at the base of your repository, so if the file is in the base directory, just use the file name. Defaults to `python3 /usr/local/bin/validate.py`.
+1. `send_email` (optional): If `true`, sends an e-mail to the submitter on the status of their submission. Default is `true`.
+1. `email_script` (required if `send_email` is `true`): If `send_email` is `true`, choose an e-mail template to send to submitters on the status of their submission. Default is a generic `send_email.py` template.
+1. `private_folders` (optional & case-sensitive): Choose which folder(s), if any, should be set to private (i.e. only available to Challenge organizers). Must be a comma-separated string of folder names, e.g. "predictions,docker_logs".
+1. `log_max_size` (optional): The maximum size of the Docker execution log (in kilobytes). Defaults to 50 kb.
+
 ### Running the workflow
 
 Run the workflow locally with default inputs and a `submissions` string input:
@@ -156,7 +156,21 @@ nextflow run main.nf -entry DATA_TO_MODEL_CHALLENGE -profile local --manifest as
 
 ## Data-to-Model Challenges
 
-### Prerequisites
+### TLDR
+
+The `DATA_TO_MODEL.nf` workflow works with all data-to-model medical Challenges hosted at Sage, but its parameters need to be customized in order to work with your particular Challenge. Please use the following steps to get started:
+
+1. Complete the pre-requesites listed under [Prerequisites for Data to Model](#Prerequisites-for-Data-to-Model).
+2. Create a pull request with your Challenge profile added to `nextflow.config` (see [Configuring the Data to Model Workflow](#Configuring-the-Data-to-Model-workflow) for further instructions).
+3. The maintainers of this repository will work with you to ensure your container is integrated with the model-to-data workflow and the parameters provided in step 2 are valid.
+4. Test the profile by making a submission to the evaluation queue represented by the given `params.view_id`. The reviewer will manually run the model-to-data workflow to ensure this new submission is picked up and processed appropriately.
+5. If the workflow is successful, the pull request can be merged and automation will be configured in the backend.
+
+### Introduction
+
+The `DATA_TO_MODEL.nf` workflow is designed to handle data-to-model Challenge formats by asynchronously running submissions, evaluating the results using the provided scoring and validation scripts, updating the Synapse project with output files, and sharing the evaluation results with users via e-mail and submissions annotations. This repository can work in conjunction with [orca-recipes](https://github.com/Sage-Bionetworks-Workflows/orca-recipes) to enable scheduled workflow execution according to your desired cadence. Please see below for a DAG outlining the processes executed in the `DATA_TO_MODEL.nf` workflow, pre-requisites for running the workflow, and how you can tailor this workflow to your specific data-to-model Challenge requirements by adding your own config profile(s) in `nextflow.config`.
+
+### Prerequisites for Data to Model
 
 In order to use this workflow, you must already have completed the following steps:
 
@@ -165,11 +179,22 @@ In order to use this workflow, you must already have completed the following ste
 1. One or more data files have already been submitted to your evaluation queue.
 1. Created a submission view that includes the `id` and `status` columns.
 
-### Configuring the workflow
+### Configuring the Data to Model workflow
 
-The workflow requires the following inputs:
+Before the data-to-model workflow can run, it must be configured for a given Challenge. Challenge organizers are required to update the `nextflow.config` file with a config profile for their custom parameters to be picked up in the workflow run. [See here](https://www.nextflow.io/docs/latest/config.html#config-profiles) for more information on Nextflow config profiles and their uses. The requested profile should use the following format:
 
-***Note:*** You must provide one of `submissions` or `manifest`. If you provide both, `submissions` will take precedence. Generally, `submissions` should be used for testing and `manifest` for automation.
+```
+my_challenge {
+    params.view_id = "syn123"
+    params.testing_data = "syn456"
+  }
+```
+
+Where the parameters are denoted by `params.[parameter_name]`. Below is the list of available parameters for configuring the `DATA_TO_MODEL.nf` workflow to a particular data-to-model Challenge. Keep in mind that most are optional, but some are required, and the workflow will not be able to run until they are provided.
+
+> [!warning]
+> Before modifying the input parameters, there are some things to consider... <br>
+> You must provide one of `submissions` or `manifest`. If you provide both, `submissions` will take precedence. Generally, `submissions` should be used for testing and `manifest` for automation.
 
 1. `submissions` (required if `manifest` is not provided): A comma separated lis tof submission IDs to evaluate.
 1. `manifest` (required if `submissions` is not provided): A path to a submission manifest containing submissions IDs to evaluate.

--- a/README.md
+++ b/README.md
@@ -237,18 +237,6 @@ nextflow run main.nf -entry DATA_TO_MODEL_CHALLENGE -profile local --manifest as
     J-->K[END];
 ```
 
-## Profiles
-
-### General Settings
-1. `local`:  Sets `cpus` = `4` and `memory` = `16.GB` for the `RUN_DOCKER` step of Model-to-Data challenges. 
-1. `tower`: Sets `cpus` = `8` and `memory` = `32.GB` for the `RUN_DOCKER` step of Model-to-Data challenges. Also includes settings for processes in need of flexible resource allocation.
-1. 'test': Sets `params.send_email` to `false`. To be used specifically for stress-testing.
-
-### Challenge-specific Settings
-1. `dynamic_challenge`: Includes Python script and Synapse Entity configuration for the AI Institute in Dynamic Systems Challenge.
-1. `pegs_challenge`: Includes Python script and Synapse Entity configuration for the PEGS Challenge.
-
-
 ## Adding Support for New Challenge Types
 
 ### Adding a New Subworkflow


### PR DESCRIPTION
### problem

The documentation as it stands is outdated, and somewhat vague about what Challenge organizers need to do to be able to integrate the model2data/data2model workflow into their Challenge pipeline.

### solution

Update the documentation accordingly 

### testing & preview
N/A