### PR TITLE
[IBCPDE-934] Handle non-Docker submissions in model2data

### DIFF
--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -52,7 +52,7 @@ def get_submission_image(syn: synapseclient.Synapse, submission_id: str) -> str:
     docker_digest = submission.get("dockerDigest", None)
     if not docker_digest or not docker_repository:
 
-        input_error = f"Input Error: Submission {submission_id} has no associated Docker image."
+        input_error = f"Submission {submission_id} has no associated Docker image"
         print(input_error)
         return input_error
     image_id = f"{docker_repository}@{docker_digest}"

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -52,7 +52,7 @@ def get_submission_image(syn: synapseclient.Synapse, submission_id: str) -> str:
     docker_digest = submission.get("dockerDigest", None)
     if not docker_digest or not docker_repository:
 
-        input_error = f"Submission {submission_id} has no associated Docker image"
+        input_error = f"InputError: Submission {submission_id} has no associated Docker image"
         print(input_error)
         return input_error
     image_id = f"{docker_repository}@{docker_digest}"
@@ -328,7 +328,7 @@ def run_docker(
 
     # If the submission is not a Docker image, create an invalid output file
     # store the error message in a log file, and end the script call
-    if "Input Error" in docker_image:
+    if "InputError" in docker_image:
 
         # Make the output directory since it wouldnt' exist without running the container
         os.makedirs(output_path)

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -51,7 +51,10 @@ def get_submission_image(syn: synapseclient.Synapse, submission_id: str) -> str:
     docker_repository = submission.get("dockerRepositoryName", None)
     docker_digest = submission.get("dockerDigest", None)
     if not docker_digest or not docker_repository:
-        return f"Input Error: Submission {submission_id} has no associated Docker image."
+
+        input_error = f"Input Error: Submission {submission_id} has no associated Docker image."
+        print(input_error)
+        return input_error
     image_id = f"{docker_repository}@{docker_digest}"
 
     return image_id

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -52,7 +52,9 @@ def get_submission_image(syn: synapseclient.Synapse, submission_id: str) -> str:
     docker_digest = submission.get("dockerDigest", None)
     if not docker_digest or not docker_repository:
 
-        input_error = f"InputError: Submission {submission_id} has no associated Docker image"
+        input_error = (
+            f"InputError: Submission {submission_id} has no associated Docker image"
+        )
         print(input_error)
         return input_error
     image_id = f"{docker_repository}@{docker_digest}"
@@ -270,7 +272,9 @@ def mount_volumes() -> dict:
     return volumes
 
 
-def validate_submission(docker_image: str, output_path: str, output_file_name: str) -> None:
+def validate_submission(
+    docker_image: str, output_path: str, output_file_name: str
+) -> None:
     """
     Validates the Docker image for the submission
 
@@ -288,9 +292,11 @@ def validate_submission(docker_image: str, output_path: str, output_file_name: s
         os.makedirs(output_path)
 
         # Create an invalid output file
-        make_invalid_output(file_name=output_file_name + ".csv",
-                            log_file_path=output_path,
-                            file_content=docker_image)
+        make_invalid_output(
+            file_name=output_file_name + ".csv",
+            log_file_path=output_path,
+            file_content=docker_image,
+        )
 
         create_log_file(
             log_file_name=log_file_name,
@@ -302,6 +308,7 @@ def validate_submission(docker_image: str, output_path: str, output_file_name: s
         return "INVALID"
 
     return "VALID"
+
 
 def run_docker(
     submission_id: str,

--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -326,6 +326,11 @@ def run_docker(
     # If the submission is not a Docker image, create an invalid output file
     # store the error message in a log file, and end the script call
     if "Input Error" in docker_image:
+
+        # Make the output directory since it wouldnt' exist without running the container
+        os.makedirs(output_path)
+
+        # Create an invalid output file
         make_invalid_output(file_name="predictions.csv",
                             log_file_path=output_path,
                             file_content=docker_image)


### PR DESCRIPTION
### problem

The pipeline should propagate the error when a user accidentally submits anything other than a Docker submission for Task 1, rather than breaking in the backend.

### solution

Remove `raise ValueError` in `get_submission_image` and instead pass it on as a string the same way other anticipated errors get passed on through the workflow, so that it ends up with the user.

### testing & preview

https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/5HhuuTlUamxp5B
https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/qHkFwe4KP1JzP

<img width="789" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/6533c741-153f-4b5f-a22f-8bc3e87261ec">

<img width="477" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/f74f22af-be31-4862-a9ad-bcf563dff531">

<img width="384" alt="image" src="https://github.com/Sage-Bionetworks-Workflows/nf-synapse-challenge/assets/32107699/e334b2e7-721c-49f4-adc4-0dcc7042ad12">
