### PR TITLE
[ORCA-331] Update default poll interval

### DIFF
--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -22,7 +22,7 @@ params.memory = "16.GB"
 // Maximum time (in minutes) to wait for Docker submission container run to complete
 params.container_timeout = "180"
 // Time (in minutes) between status checks during container monitoring
-params.poll_interval = "10"
+params.poll_interval = "1"
 // The container that houses the scoring and validation scripts
 params.challenge_container = "ghcr.io/jaymedina/test_model2data:latest"
 // The command used to execute the Challenge scoring script in the base directory of the challenge_container: e.g. `python3 path/to/score.py`


### PR DESCRIPTION
## problem

I suspect the default poll interval of 10 mins is way too long for most cases.

## solution

Update the poll interval (i.e. the frequency at which the Docker submission container gets polled to see if it's still running) to every 1 min to avoid slow processing

## testing

This will not be tested since it's just a poll interval update