### PR TITLE
[ORCA-332] Check that submissions to the dynamic challenge are files

### DIFF
--- a/bin/download_submission.py
+++ b/bin/download_submission.py
@@ -9,7 +9,7 @@ submission_id = sys.argv[1]
 syn = synapseclient.Synapse()
 syn.login(silent=True)
 
-submission = syn.getSubmission(submission_id)
+submission = syn.getSubmission(submission_id, downloadLocation=".")
 entity_type = submission["entity"].concreteType
 if entity_type != "org.sagebionetworks.repo.model.FileEntity":
     open("dummy.txt", 'w').close()

--- a/bin/download_submission.py
+++ b/bin/download_submission.py
@@ -1,17 +1,27 @@
 #!/usr/bin/env python3
 
+import argparse
 import sys
 
 import synapseclient
 
-submission_id = sys.argv[1]
+def get_args():
+    """Set up command-line interface and get arguments without any flags."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("submission_id", type=str, help="The ID of submission")
 
-syn = synapseclient.Synapse()
-syn.login(silent=True)
+    return parser.parse_args()
 
-submission = syn.getSubmission(submission_id, downloadLocation=".")
-entity_type = submission["entity"].concreteType
-if entity_type != "org.sagebionetworks.repo.model.FileEntity":
-    open("dummy.txt", 'w').close()
+if __name__ == "__main__":
+    args = get_args()
+    submission_id = args.submission_id
 
-print(entity_type)
+    syn = synapseclient.Synapse()
+    syn.login(silent=True)
+
+    submission = syn.getSubmission(submission_id, downloadLocation=".")
+    entity_type = submission["entity"].concreteType
+    if entity_type != "org.sagebionetworks.repo.model.FileEntity":
+        open("dummy.txt", 'w').close()
+
+    print(entity_type)

--- a/bin/download_submission.py
+++ b/bin/download_submission.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import sys
+
+import synapseclient
+
+submission_id = sys.argv[1]
+
+syn = synapseclient.Synapse()
+syn.login(silent=True)
+
+submission = syn.getSubmission(submission_id)
+entity_type = submission["entity"].concreteType
+if entity_type != "org.sagebionetworks.repo.model.File":
+    open("dummy.txt", 'w').close()
+
+print(entity_type)

--- a/bin/download_submission.py
+++ b/bin/download_submission.py
@@ -11,7 +11,7 @@ syn.login(silent=True)
 
 submission = syn.getSubmission(submission_id)
 entity_type = submission["entity"].concreteType
-if entity_type != "org.sagebionetworks.repo.model.File":
+if entity_type != "org.sagebionetworks.repo.model.FileEntity":
     open("dummy.txt", 'w').close()
 
 print(entity_type)

--- a/bin/dynamic_challenge_validate.py
+++ b/bin/dynamic_challenge_validate.py
@@ -17,10 +17,10 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("submission_id", type=str, help="The ID of submission")
     parser.add_argument(
-        "predictions_path", type=str, help="The path to the predictions folder"
+        "entity_type", type=str, help="The entity type of the submission"
     )
     parser.add_argument(
-        "entity_type", type=str, help="The entity type of the submission"
+        "predictions_path", type=str, help="The path to the predictions folder"
     )
     parser.add_argument(
         "output",

--- a/bin/dynamic_challenge_validate.py
+++ b/bin/dynamic_challenge_validate.py
@@ -120,7 +120,7 @@ if __name__ == "__main__":
     if entity_type != "org.sagebionetworks.repo.model.File":
         prediction_status = INVALID
         invalid_reasons.append(
-            f"Submission Entities must be of type 'org.sagebionetworks.repo.model.File', submitted Entity is {entity_type}"
+            f"Submission Entities must be of type 'org.sagebionetworks.repo.model.File', submitted Entity is '{entity_type}'."
         )
     elif predictions_path is None or os.path.basename(predictions_path) != 'predictions.tar':
         prediction_status = INVALID

--- a/bin/dynamic_challenge_validate.py
+++ b/bin/dynamic_challenge_validate.py
@@ -117,10 +117,10 @@ if __name__ == "__main__":
 
     invalid_reasons = []
 
-    if entity_type != "org.sagebionetworks.repo.model.File":
+    if entity_type != "org.sagebionetworks.repo.model.FileEntity":
         prediction_status = INVALID
         invalid_reasons.append(
-            f"Submission Entities must be of type 'org.sagebionetworks.repo.model.File', submitted Entity is '{entity_type}'."
+            f"Submission Entities must be of type 'org.sagebionetworks.repo.model.FileEntity', submitted Entity is '{entity_type}'."
         )
     elif predictions_path is None or os.path.basename(predictions_path) != 'predictions.tar':
         prediction_status = INVALID

--- a/bin/dynamic_challenge_validate.py
+++ b/bin/dynamic_challenge_validate.py
@@ -20,6 +20,9 @@ def get_args():
         "predictions_path", type=str, help="The path to the predictions folder"
     )
     parser.add_argument(
+        "entity_type", type=str, help="The entity type of the submission"
+    )
+    parser.add_argument(
         "output",
         type=str,
         nargs="?",
@@ -102,6 +105,7 @@ if __name__ == "__main__":
     args = get_args()
     sub_id = args.submission_id
     predictions_path = args.predictions_path
+    entity_type = args.entity_type
     results_path = args.output
 
     # login to synapase
@@ -113,7 +117,12 @@ if __name__ == "__main__":
 
     invalid_reasons = []
 
-    if predictions_path is None or os.path.basename(predictions_path) != 'predictions.tar':
+    if entity_type != "org.sagebionetworks.repo.model.File":
+        prediction_status = INVALID
+        invalid_reasons.append(
+            f"Submission Entities must be of type 'org.sagebionetworks.repo.model.File', submitted Entity is {entity_type}"
+        )
+    elif predictions_path is None or os.path.basename(predictions_path) != 'predictions.tar':
         prediction_status = INVALID
         invalid_reasons.append('Error:  No "predictions.tar" found')
     else:

--- a/modules/download_submission.nf
+++ b/modules/download_submission.nf
@@ -16,8 +16,12 @@ process DOWNLOAD_SUBMISSION {
 
     script:
     """
-    challengeutils download-submission ${submission_id}
-    ls -A
+    download_output=\$(challengeutils download-submission ${submission_id})
+
+    if [[ ! ${download_output} == *"org.sagebionetworks.repo.model.FileEntity"* ]];
+    then
+        echo "download failed"
+        echo "${download_output}"
+        touch dummy.txt
     """
-    // if [ -z "\$(ls -A)" ]; then touch dummy.txt; fi
 }

--- a/modules/download_submission.nf
+++ b/modules/download_submission.nf
@@ -16,5 +16,7 @@ process DOWNLOAD_SUBMISSION {
     script:
     """
     challengeutils download-submission ${submission_id}
+    ls -A
     """
+    // if [ -z "\$(ls -A)" ]; then touch dummy.txt; fi
 }

--- a/modules/download_submission.nf
+++ b/modules/download_submission.nf
@@ -5,23 +5,17 @@ process DOWNLOAD_SUBMISSION {
     label "flexible_compute"
     
     secret "SYNAPSE_AUTH_TOKEN"
-    container "sagebionetworks/challengeutils:v4.2.0"
+    container "sagebionetworks/synapsepythonclient:v4.0.0"
 
     input:
     val submission_id
     val ready
 
     output:
-    tuple val(submission_id), path('*')
+    tuple val(submission_id), path('*'), env(entity_type)
 
     script:
     """
-    download_output=\$(challengeutils download-submission ${submission_id})
-
-    if [[ ! ${download_output} == *"org.sagebionetworks.repo.model.FileEntity"* ]];
-    then
-        echo "download failed"
-        echo "${download_output}"
-        touch dummy.txt
+    entity_type=\$(download_submission.py '${submission_id}')
     """
 }

--- a/modules/download_submission.nf
+++ b/modules/download_submission.nf
@@ -1,6 +1,5 @@
 // download submission file(s) for Data to Model Challenges
 process DOWNLOAD_SUBMISSION {
-    debug true
     tag "${submission_id}"
     label "flexible_compute"
     

--- a/modules/download_submission.nf
+++ b/modules/download_submission.nf
@@ -1,5 +1,6 @@
 // download submission file(s) for Data to Model Challenges
 process DOWNLOAD_SUBMISSION {
+    debug true
     tag "${submission_id}"
     label "flexible_compute"
     

--- a/modules/validate_data_to_model.nf
+++ b/modules/validate_data_to_model.nf
@@ -7,7 +7,7 @@ process VALIDATE {
     container "sagebionetworks/synapsepythonclient:v4.0.0"
 
     input:
-    tuple val(submission_id), path(predictions)
+    tuple val(submission_id), path(predictions), val(entity_type)
     val ready
     val validation_script
 
@@ -16,6 +16,6 @@ process VALIDATE {
 
     script:
     """
-    status=\$(${validation_script} '${submission_id}' '${predictions}')
+    status=\$(${validation_script} '${submission_id}' '${entity_type}' '${predictions}')
     """
 }


### PR DESCRIPTION
**Problem:**
Recently, we had a submission to the Dynamic Challenge which caused the data-to-model workflow to fail. The reason for the failure was that the Synapse entity submitted to the challenge was a Project, rather than a File.

**Solution:**
Collect the entity `concreteType` from the submission during the `DOWNLOAD_SUBMISSION` step and pass this along to the `VALIDATE` step. Also add a check in `dynamic_challenge_validate.py` that will mark the submission as `INVALID` if the submitted entity is not a file.

**Testing:**
This change has been tested in Seqera Platform in three different contexts, and the desired outcome happened in each instance.
- Project entity submission [run](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/dynamic-challenge-project/watch/5Z8e3hSG456ioe) - Submission 9746080 invalid
- Folder entity submission [run](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/dynamic-challenge-project/watch/21KGfuwaXHb427) - Submission 9746082 invalid
- File entity submission [run](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/dynamic-challenge-project/watch/2dF4htxBaodJCA) - Submission 9746087 valid

**Notes:**
- Because we are passing the path to the submission file in a channel from `DOWNLOAD_SUBMISSION` to `VALIDATE`, there needs to be a file to pass or the workflow will fail. In the instance where the submission is not a file (and therefore no file is downloaded) we create a dummy file in the `DOWNLOAD_SUBMISSION` step.