### PR TITLE
[ORCA-334] Remove `mem_limit` arg

### DIFF
--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -484,8 +484,7 @@ def run_docker(
             docker_image,
             detach=True,
             volumes=volumes,
-            network_disabled=True,
-            mem_limit="6g",
+            network_disabled=True
         )
 
         timeout_msg = monitor_container(


### PR DESCRIPTION
## problem
A user was having problem with their model being evaluated because their script was loading in an RDS file >7GB in size. The container exited with the logs showing no indication of error.

## solution
The memory capacity for the submission container was being capped at 6GB. Remove the `mem_limit` argument so that we use all of the memory capacity allocated to the `RUN_DOCKER` container.

## testing
A test was done on the same submission referenced by the user (`send_email` is set to `false`). [Results](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/qZ7Iaem7dDof4) 

Their docker log now shows that the data is being loaded:

<img width="239" alt="image" src="https://github.com/user-attachments/assets/a9a2cbcc-5379-4d71-8103-6b684d77aa0d">