### PR TITLE
Assign timeout_msg before try/except block to prevent UnboundError

### DIFF
--- a/bin/run_docker.py
+++ b/bin/run_docker.py
@@ -478,6 +478,7 @@ def run_docker(
         return
 
     # Run the docker image using the client. We detach so that we can monitor the container.
+    timeout_msg = ""
     print(f"Running container... {docker_image}")
     try:
         container = client.containers.run(


### PR DESCRIPTION
## problem

`timeout_msg` is not assigned outside the `try` block, so if a container fails to be executed before we can get to `monitor_container`, `timeout_msg` is not an assigned variable. This has the potential to break logic further down the script which assumes `timeout_msg` is assigned regardless of whether or not a container was successfully run.

## solution

Assign `timeout_msg` outside the try/except block

## testing

Successful workflow run pointed to this branch: https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/pegs-challenge-project/watch/cmpl2lkwgAm5I