### PR TITLE
No e-mail for pegs_challenge_test

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -46,7 +46,7 @@ profiles {
     params.goldstandard_id = "syn58888786"
     params.private_folders = "predictions"
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/pegs-evaluation:latest"
-    params.email_script = "send_email.py"
+    params.send_email = false
   }
 	tower {
     process {


### PR DESCRIPTION
## problem

The `pegs_challenge_test` profile (for the final round of PEGS) had `send_email` set to the default `true`. Update this so that e-mails are not sent to the participants with the scores.

## solution

Set `send_email = false`