### PR TITLE
No score in e-mail for PEGS

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -46,6 +46,7 @@ profiles {
     params.goldstandard_id = "syn58888786"
     params.private_folders = "predictions"
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/pegs-evaluation:latest"
+    params.send_email = true
     params.email_with_score = "no"
   }
 	tower {

--- a/nextflow.config
+++ b/nextflow.config
@@ -46,7 +46,7 @@ profiles {
     params.goldstandard_id = "syn58888786"
     params.private_folders = "predictions"
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/pegs-evaluation:latest"
-    params.send_email = false
+    params.email_with_score = "no"
   }
 	tower {
     process {


### PR DESCRIPTION
## problem

We want e-mails sent out to participants, just not with a score value.

## solution

Set `email_with_score` to `"no"`

## testing

[Workflow run](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/pegs-challenge-project/watch/3GJ7RJdI4wtD5K) for INVALID submission
[Workflow run](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/pegs-challenge-project/watch/1qkM479j3l4a7f) for VALID submission