### PR TITLE
[DPE-1240] Updates Entrypoint Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,16 @@ A general purpose Nextflow workflow for evaluating submissions to challenges hos
 
 ## Overview
 
-This repository is structured so that each challenge type has its own subworkflow which is wrapped by a uniquely named workflow in `main.nf`. This allows users to invoke the workflow appropriate for their challenge by using the `entry` parameter locally:
+This repository is structured so that each challenge type has its own subworkflow which is wrapped by a uniquely named workflow in `main.nf`. This allows users to invoke the workflow appropriate for their challenge by using the `params.entry` parameter or a pre-configured profile from `nextflow.config` locally:
 ```
-nextflow run main.nf -entry {subworkflow_name} -profile local
+nextflow run main.nf --entry {workflow_name} -profile local
 ```
-or on Nextflow Tower by using the `Workflow entry name` field under `Advanced options`.
+OR
+```
+nextflow run main.nf -profile {profile_name}
+```
+
+or on Seqera Platform by setting the `entry` parameter in the `Pipeline parameters` section or by choosing a pre-configured profile from the `Config profiles` dropdown menu.
 
 ## Setup
 
@@ -97,7 +102,8 @@ If you are new to containerization and/or the GHCR, [see here](https://docs.gith
 Before the model-to-data workflow can run, it must be configured for a given Challenge. Challenge organizers are required to update the `nextflow.config` file with a config profile for their custom parameters to be picked up in the workflow run. [See here](https://www.nextflow.io/docs/latest/config.html#config-profiles) for more information on Nextflow config profiles and their uses. The requested profile should use the following format:
 
 ```
-my_challenge {
+my_model_to_data_challenge {
+    params.entry = 'model_to_data'
     params.view_id = "syn123"
     params.data_folder_id = "syn456"
     params.project_name = "My Project (Write it as it appears on Synapse!)"
@@ -124,6 +130,7 @@ Where the parameters are denoted by `params.[parameter_name]`. Below is the list
 > ```
 > Ensure that your scripts can be called in this way without issue.
 
+1. `entry` (required): The name of the workflow to run. Must be set to `model_to_data`.
 1. `submissions` (required if `manifest` is not provided): A comma separated list of submission IDs to evaluate.
 1. `manifest` (required if `submissions` is not provided): A path to a submission manifest containing submissions IDs to evaluate.
 1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in.
@@ -145,12 +152,12 @@ Where the parameters are denoted by `params.[parameter_name]`. Below is the list
 
 Run the workflow locally with default inputs and a `submissions` string input:
 ```
-nextflow run main.nf -entry MODEL_TO_DATA_CHALLENGE -profile local --submissions 9741046,9741047
+nextflow run main.nf --entry model_to_data -profile local --submissions 9741046,9741047
 ```
 
 With a `manifest` input:
 ```
-nextflow run main.nf -entry DATA_TO_MODEL_CHALLENGE -profile local --manifest assets/model_to_data_submission_manifest.csv
+nextflow run main.nf --entry data_to_model -profile local --manifest assets/model_to_data_submission_manifest.csv
 ```
 
 
@@ -184,7 +191,8 @@ In order to use this workflow, you must already have completed the following ste
 Before the data-to-model workflow can run, it must be configured for a given Challenge. Challenge organizers are required to update the `nextflow.config` file with a config profile for their custom parameters to be picked up in the workflow run. [See here](https://www.nextflow.io/docs/latest/config.html#config-profiles) for more information on Nextflow config profiles and their uses. The requested profile should use the following format:
 
 ```
-my_challenge {
+my_data_to_model_challenge {
+    params.entry = 'data_to_model'
     params.view_id = "syn123"
     params.testing_data = "syn456"
   }
@@ -209,6 +217,7 @@ Where the parameters are denoted by `params.[parameter_name]`. Below is the list
 > ```
 > Ensure that your scripts can be called in this way without issue.
 
+1. `entry` (required): The name of the workflow to run. Must be set to `data_to_model`.
 1. `submissions` (required if `manifest` is not provided): A comma separated lis tof submission IDs to evaluate.
 1. `manifest` (required if `submissions` is not provided): A path to a submission manifest containing submissions IDs to evaluate.
 1. `view_id` (required): The Synapse ID for your submission view.
@@ -225,12 +234,12 @@ Where the parameters are denoted by `params.[parameter_name]`. Below is the list
 
 Run the workflow locally with default inputs and a `submissions` string input:
 ```
-nextflow run main.nf -entry DATA_TO_MODEL_CHALLENGE -profile local --submissions 9741046,9741047
+nextflow run main.nf --entry data_to_model -profile local --submissions 9741046,9741047
 ```
 
 With a `manifest` input:
 ```
-nextflow run main.nf -entry DATA_TO_MODEL_CHALLENGE -profile local --manifest assets/data_to_model_submission_manifest.csv
+nextflow run main.nf --entry data_to_model -profile local --manifest assets/data_to_model_submission_manifest.csv
 ```
 
 ### Workflow DAG
@@ -258,7 +267,7 @@ nextflow run main.nf -entry DATA_TO_MODEL_CHALLENGE -profile local --manifest as
 
 If you would like to add support for a new challenge type, you can do so by creating a new subworkflow in the `subworkflows` directory. Name your subworkflow clearly with the name of the new challenge type. You should try to use the existing library of modules to build your subworkflow. It is important to not change the logic of existing modules to avoid breaking other subworkflows. Rather, you should add new process definitions to the `modules` folder and give them clear names that indicate their purpose. Once you have created your subworkflow, you can add it to the `main.nf` file and test it using:
 ```
-nextflow run main.nf -entry {your_new_subworkflow_name}
+nextflow run main.nf --entry {your_new_subworkflow_name}
 ```
 
 ### Adding New Scoring and Validation Scripts

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A general purpose Nextflow workflow for evaluating submissions to challenges hos
 
 This repository is structured so that each challenge type has its own subworkflow which is wrapped by a uniquely named workflow in `main.nf`. This allows users to invoke the workflow appropriate for their challenge by using the `params.entry` parameter or a pre-configured profile from `nextflow.config` locally:
 ```
-nextflow run main.nf --entry {workflow_name} -profile local
+nextflow run main.nf --entry {workflow_name} [... other required params]
 ```
 OR
 ```
@@ -130,7 +130,7 @@ Where the parameters are denoted by `params.[parameter_name]`. Below is the list
 > ```
 > Ensure that your scripts can be called in this way without issue.
 
-1. `entry` (required): The name of the workflow to run. Must be set to `model_to_data`.
+1. `entry` (required & case-sensitive): The name of the workflow to run. Must be set to `model_to_data`.
 1. `submissions` (required if `manifest` is not provided): A comma separated list of submission IDs to evaluate.
 1. `manifest` (required if `submissions` is not provided): A path to a submission manifest containing submissions IDs to evaluate.
 1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in.
@@ -217,7 +217,7 @@ Where the parameters are denoted by `params.[parameter_name]`. Below is the list
 > ```
 > Ensure that your scripts can be called in this way without issue.
 
-1. `entry` (required): The name of the workflow to run. Must be set to `data_to_model`.
+1. `entry` (required & case-sensitive): The name of the workflow to run. Must be set to `data_to_model`.
 1. `submissions` (required if `manifest` is not provided): A comma separated lis tof submission IDs to evaluate.
 1. `manifest` (required if `submissions` is not provided): A path to a submission manifest containing submissions IDs to evaluate.
 1. `view_id` (required): The Synapse ID for your submission view.

--- a/main.nf
+++ b/main.nf
@@ -1,15 +1,25 @@
 nextflow.enable.dsl = 2
 
+valid_entry_points = ['data_to_model', 'model_to_data']
+if (!params.entry) {
+    error "Entry point must be specified using --entry. Select one of: ${valid_entry_points.join(', ')}"
+}
+if (!valid_entry_points.contains(params.entry)) {
+    error "Invalid entry point: '${params.entry}'. Valid options are: ${valid_entry_points.join(', ')}"
+}
+
 // Run this for data to model challenges
 include { DATA_TO_MODEL } from './workflows/DATA_TO_MODEL.nf'
-
-workflow DATA_TO_MODEL_CHALLENGE {
-    DATA_TO_MODEL ()
-}
 
 // Run this for model to data challenges
 include { MODEL_TO_DATA } from './workflows/MODEL_TO_DATA.nf'
 
-workflow MODEL_TO_DATA_CHALLENGE {
-    MODEL_TO_DATA ()
+workflow {
+    if (params.entry == 'data_to_model') {
+        DATA_TO_MODEL ()
+    } else if (params.entry == 'model_to_data') {
+        MODEL_TO_DATA ()
+    } else {
+        error "Invalid entry point: '${params.entry}'. Valid options are: ${valid_entry_points.join(', ')}"
+    }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,12 +24,14 @@ profiles {
     params.send_email = false
   }
   data_to_model_prototype {
+    params.entry = 'data_to_model'
     params.submissions = "9751432"
     params.view_id = "syn52576179"
     params.groundtruth_id = "syn65491926"
     params.challenge_container = "ghcr.io/jaymedina/jenny-test-evaluation:latest"
   }
   model_to_data_prototype {
+    params.entry = 'model_to_data'
     params.submissions = ""
     params.project_name = "DPE-testing"
     params.view_id = "syn53770151"
@@ -38,6 +40,7 @@ profiles {
     params.challenge_container = "ghcr.io/jaymedina/test_model2data:latest"
   }
   dynamic_challenge {
+    params.entry = 'data_to_model'
     params.view_id = "syn52658661"
     params.testing_data = "syn53627077"
     params.scoring_script = "dynamic_challenge_score.py"
@@ -45,6 +48,7 @@ profiles {
     params.email_script = "dynamic_challenge_send_email.py"
   }
   pegs_challenge_validate {
+    params.entry = 'model_to_data'
     params.project_name = "PEGS DREAM Challenge"
     params.view_id = "syn57373526"
     params.data_folder_id = "syn61464987"
@@ -54,6 +58,7 @@ profiles {
     params.email_script = "send_email.py"
   }
   pegs_challenge_test {
+    params.entry = 'model_to_data'
     params.project_name = "PEGS DREAM Challenge"
     params.view_id = "syn58942525"
     params.data_folder_id = "syn61485785"


### PR DESCRIPTION
# **Problem:**

Recently while in conversations with Code Ocean, it was brought to my attention that Seqera has deprecated support for the entry[ CLI option ](https://www.nextflow.io/docs/latest/reference/cli.html#cli-reference)for Nextflow as of 24.10.0.

> -entry
> Deprecated since version 24.10.0: Use params in the entry workflow to call different workflows from the command line.

We currently rely on this option in both the nf-synapse and nf-synapse-challenge workflows to toggle between workflows to execute. Based on the suggestion quoted above, Seqera seems to recommend that a normal parameter be used instead. Therefore, we will need some sort of toggling logic built into the workflows that expects a parameter to be set.

# **Solution:**

Implement a simple and easy to copy method for providing an entrypoint to params.entry instead of the special entry option. I also updated existing profiles to set the params.entry accordingly.

I had initially wanted to create a more robust tool that could be used to convert any of our Nextflow repositories to a multi-workflow tool without need for repeating the same if/else-type logic in more than one place, but abandoned the effort in favor of this more straightforward approach after determining that it likely wasn't worth maintaining a separate tool (a Nextflow Plugin) for this purpose. See this [ticket](https://sagebionetworks.jira.com/browse/DPE-1240) in Jira for more context.

See this `nf-synapse` [PR](https://github.com/Sage-Bionetworks-Workflows/nf-synapse/pull/11) for discussion.

# **Testing:**

Tested the workflow on Seqera Platform (dev) for both [model-to-data](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/4xcIWFtMZKO4vJ) and [data-to-model](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2cBnsMOnZ7Q3Dq) and also for error handling in the [case](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2Bvtui0CplUeJe) that an invalid `entry` value is passed to the workflow.

`README.md` was updated to reflect the changes introduced here.

# **Notes:**

Before merging this PR, we will need to inform users of the change so they understand how the default behavior of this workflow will change. We have specific revisions of this workflow pinned in the Airflow DAGs that automate submission evaluation, so this change should not impact any ongoing challenges (like the Dynamic Challenge), but we should let the challenges team know in case they need to test anything out going forward.
