### PR TITLE
Add DREAM Olfactory Challenge Profile to nextflow.config

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -68,6 +68,15 @@ profiles {
     params.send_email = true
     params.email_with_score = "no"
   }
+  olfactory25_challenge_validate {
+    params.entry = 'model_to_data'
+    params.view_id = "syn66279193"
+    params.data_folder_id = "syn65916674"
+    params.project_name = "DREAM Olfactory Mixtures Prediction Challenge 2025"
+    params.groundtruth_id = "syn65916675"
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
+    params.email_script = "send_email.py"
+  }
 	tower {
     process {
       withName: RUN_DOCKER {

--- a/nextflow.config
+++ b/nextflow.config
@@ -69,7 +69,7 @@ profiles {
     params.email_with_score = "no"
   }
   olfactory25_challenge_validate {
-    params.entry = 'model_to_data'
+    params.entry = 'data_to_model'
     params.view_id = "syn66279193"
     params.data_folder_id = "syn65916674"
     params.project_name = "DREAM Olfactory Mixtures Prediction Challenge 2025"

--- a/nextflow.config
+++ b/nextflow.config
@@ -71,8 +71,6 @@ profiles {
   olfactory25_challenge_validate {
     params.entry = 'data_to_model'
     params.view_id = "syn66279193"
-    params.data_folder_id = "syn65916674"
-    params.project_name = "DREAM Olfactory Mixtures Prediction Challenge 2025"
     params.groundtruth_id = "syn65916675"
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
     params.email_script = "send_email.py"


### PR DESCRIPTION
Changelog
Add profile to `nextflow.config` for DREAM Olfactory Mixtures Prediction Challenge 2025 (see [Slack message](https://sagebionetworks.slack.com/archives/C08NTMHJXHQ/p1744926678471309?thread_ts=1744923396.807119&cid=C08NTMHJXHQ) for context)
