### PR TITLE
[DPE-1267] reintroduce send_email_before

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Where the parameters are denoted by `params.[parameter_name]`. Below is the list
 1. `submissions` (required if `manifest` is not provided): A comma separated lis tof submission IDs to evaluate.
 1. `manifest` (required if `submissions` is not provided): A path to a submission manifest containing submissions IDs to evaluate.
 1. `view_id` (required): The Synapse ID for your submission view.
+1. `project_name` (required & case-sensitive): The name of your Project the Challenge is running in.
 1. `groundtruth_id` (required): The Synapse ID for the folder holding the ground truth file for submissions.
 1. `challenge_container` (required): The name of the container that the scoring and validation scripts are housed in, and will be executed in, during the validation and scoring steps of the workflow.
 1. `file_type` (optional): The expected file type of the submissions. Defaults to `csv`.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,37 @@ The `DATA_TO_MODEL.nf` workflow works with all data-to-model medical Challenges 
 
 The `DATA_TO_MODEL.nf` workflow is designed to handle data-to-model Challenge formats by asynchronously running submissions, evaluating the results using the provided scoring and validation scripts, updating the Synapse project with output files, and sharing the evaluation results with users via e-mail and submissions annotations. This repository can work in conjunction with [orca-recipes](https://github.com/Sage-Bionetworks-Workflows/orca-recipes) to enable scheduled workflow execution according to your desired cadence. Please see below for a DAG outlining the processes executed in the `DATA_TO_MODEL.nf` workflow, pre-requisites for running the workflow, and how you can tailor this workflow to your specific data-to-model Challenge requirements by adding your own config profile(s) in `nextflow.config`.
 
+### Workflow DAG
+
+```mermaid
+  flowchart LR
+    %% Phase 0 & 1: Setup & pre-email
+    A[CREATE_SUBMISSION_CHANNEL] --> B[UPDATE_SUBMISSION_STATUS_BEFORE_EVALUATION]
+    B --> C[SEND_EMAIL_BEFORE]
+
+    %% Phase 2: Data prep
+    C --> D[SYNAPSE_STAGE_GROUNDTRUTH]
+    C --> E[DOWNLOAD_SUBMISSION]
+
+    %% Phase 3: Validation
+    D --> F[VALIDATE]
+    E --> F
+    F --> G[UPDATE_SUBMISSION_STATUS_AFTER_VALIDATE]
+    F --> H[ANNOTATE_SUBMISSION_AFTER_VALIDATE]
+
+    %% Phase 4: Scoring
+    G --> I[SCORE]
+    H --> I
+    I --> J[UPDATE_SUBMISSION_STATUS_AFTER_SCORE]
+    I --> K[ANNOTATE_SUBMISSION_AFTER_SCORE]
+
+    %% Post-score email & end
+    J --> L[SEND_EMAIL_AFTER]
+    K --> L
+    L --> M[END]
+
+```
+
 ### Prerequisites for Data to Model
 
 In order to use this workflow, you must already have completed the following steps:
@@ -272,25 +303,6 @@ nextflow run main.nf --entry data_to_model -profile local --submissions 9741046,
 With a `manifest` input:
 ```
 nextflow run main.nf --entry data_to_model -profile local --manifest assets/data_to_model_submission_manifest.csv
-```
-
-### Workflow DAG
-
-```mermaid
-  flowchart LR;
-    L[SEND EMAIL BEFORE];
-    A[SYNAPSE STAGE]-->G[SCORE];
-    B[UPDATE STATUS]-->C[DOWNLOAD SUBMISSION];
-    C-->D[VALIDATE];
-    D-->E[ANNOTATE];
-    D-->F[UPDATE STATUS];
-    E-->G;
-    F-->G;
-    G-->H[ANNOTATE];
-    G-->I[UPDATE STATUS];
-    H-->J[SEND EMAIL AFTER];
-    I-->J;
-    J-->K[END];
 ```
 
 ## Adding Support for New Challenge Types

--- a/bin/helpers.py
+++ b/bin/helpers.py
@@ -4,6 +4,7 @@ import os
 from typing import List
 
 import synapseclient
+from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.models.team import Team
 from synapseclient.models.user import UserProfile
 
@@ -48,7 +49,7 @@ def get_participant_name(syn: synapseclient.Synapse, participant_id: List[int]) 
     """
     try:
         name = UserProfile.from_id(participant_id[0], synapse_client=syn).username
-    except Exception as e:
+    except SynapseHTTPError:
         name = Team.from_id(participant_id[0], synapse_client=syn).name
 
     return name

--- a/bin/helpers.py
+++ b/bin/helpers.py
@@ -4,6 +4,8 @@ import os
 from typing import List
 
 import synapseclient
+from synapseclient.models.team import Team
+from synapseclient.models.user import UserProfile
 
 
 def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[str]:
@@ -29,6 +31,27 @@ def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[s
     # Ensure that the participant_id returned is a list
     # so it can be fed into syn.sendMessage(...) later.
     return [participant_id]
+
+
+def get_participant_name(syn: synapseclient.Synapse, participant_id: list) -> str:
+    """
+    Retrieves the name of a participant.
+    If it's a user, then the username is retrieved. If it's a team, then the team name is retrieved.
+
+    Arguments:
+        syn: A Synapse Python client instance
+        participant_id: A list containing the ID of the participant
+
+    Returns:
+        The name of the participant
+
+    """
+    try:
+        name = UserProfile.from_id(participant_id[0]).username
+    except Exception as e:
+        name = Team.from_id(participant_id[0]).name
+
+    return name
 
 
 def rename_file(submission_id: str, input_path: str) -> None:

--- a/bin/helpers.py
+++ b/bin/helpers.py
@@ -47,9 +47,9 @@ def get_participant_name(syn: synapseclient.Synapse, participant_id: list) -> st
 
     """
     try:
-        name = UserProfile.from_id(participant_id[0]).username
+        name = UserProfile.from_id(participant_id[0], synapse_client=syn).username
     except Exception as e:
-        name = Team.from_id(participant_id[0]).name
+        name = Team.from_id(participant_id[0], synapse_client=syn).name
 
     return name
 

--- a/bin/helpers.py
+++ b/bin/helpers.py
@@ -8,7 +8,7 @@ from synapseclient.models.team import Team
 from synapseclient.models.user import UserProfile
 
 
-def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[str]:
+def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[int]:
     """
     Retrieves the teamId of the participating team that made
     the submission. If the submitter is an individual rather than
@@ -30,10 +30,10 @@ def get_participant_id(syn: synapseclient.Synapse, submission_id: str) -> List[s
 
     # Ensure that the participant_id returned is a list
     # so it can be fed into syn.sendMessage(...) later.
-    return [participant_id]
+    return [int(participant_id)]
 
 
-def get_participant_name(syn: synapseclient.Synapse, participant_id: list) -> str:
+def get_participant_name(syn: synapseclient.Synapse, participant_id: List[int]) -> str:
     """
     Retrieves the name of a participant.
     If it's a user, then the username is retrieved. If it's a team, then the team name is retrieved.

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -178,8 +178,6 @@ if __name__ == "__main__":
     view_id = sys.argv[1]
     submission_id = sys.argv[2]
     email_with_score = sys.argv[3]
-    # This is here despite not currently being used.
-    # This is so that we can still use one `send_email.nf` process while supporting both `BEFORE` and `AFTER` notifications
     notification_type = sys.argv[4]
 
     send_email(view_id, submission_id, email_with_score, notification_type)

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -152,7 +152,7 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
         subject = f"Evaluation Started: {submission_id}"
         body = (
             f"Dear participant,\n\n"
-            f"Your submission **{submission_id}** is now being evaluated. "
+            f"Your submission <b>{submission_id}</b> is now being evaluated. "
             "We will notify you again once the evaluation completes.\n\n"
             "Thank you for your participation!\n\n"
             "The Challenge Organizers"

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -142,10 +142,10 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
     # Get MODEL_TO_DATA annotations for the given submission
     submission_annotations = get_annotations(syn, submission_id)
 
-    # Get the Synapse users to send an e-mail to
+    # Get the Synapse user/team to send an e-mail to
     participant_id = helpers.get_participant_id(syn, submission_id)
 
-    # Get the name of the participant(s)
+    # Get the name of the participant user/team
     participant_name = helpers.get_participant_name(syn, participant_id)
 
     # Create the subject and body of the e-mail message, depending on

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -50,17 +50,17 @@ def email_template(
         (
             "VALIDATED",
             "yes",
-        ): f"Submission {submission_id} has been evaluated with the following scores:\n"
+        ): f"Submission <b>{submission_id}</b> for the <b>{project_name}</b> project has been evaluated with the following scores:\n"
         + "\n".join(get_score_dict(score))
         + f"\nView all your scores here: https://www.synapse.org/#!Synapse:{view_id}/tables/",
         (
             "VALIDATED",
             "no",
-        ): f"Submission {submission_id} has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
+        ): f"Submission <b>{submission_id}</b> for the <b>{project_name}</b> project has been evaluated. Your score will be available after Challenge submissions are closed. Thank you for participating!",
         (
             "INVALID",
             "yes",
-        ): f"Evaluation failed for Submission {submission_id}."
+        ): f"Evaluation failed for Submission <b>{submission_id}</b> for the <b>{project_name}</b> project."
         + "\n"
         + f"Reason: '{reason}'."
         + "\n\n"
@@ -68,7 +68,7 @@ def email_template(
         (
             "INVALID",
             "no",
-        ): f"Evaluation failed for Submission {submission_id}."
+        ): f"Evaluation failed for Submission <b>{submission_id}</b> for the <b>{project_name}</b> project."
         + "\n"
         + f"Reason: '{reason}'."
         + "\n"
@@ -155,7 +155,7 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
         subject = f"Evaluation Started: {submission_id}"
         body = (
             f"Dear {participant_name},\n\n"
-            f"Your submission <b>{submission_id}</b> for the {project_name} project is now being evaluated. "
+            f"Your submission <b>{submission_id}</b> for the <b>{project_name}</b> project is now being evaluated. "
             "We will notify you again once the evaluation completes.\n\n"
             "Thank you for your participation!\n\n"
             "The Challenge Organizers"

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -143,6 +143,8 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
     # Get the Synapse users to send an e-mail to
     ids_to_notify = helpers.get_participant_id(syn, submission_id)
 
+    # Create the subject and body of the e-mail message, depending on
+    # the notification type and submission status:
     if notification_type.upper() == "BEFORE":
         # Before-evaluation notification
         subject = f"Evaluation Started: {submission_id}"

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -143,10 +143,10 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
     submission_annotations = get_annotations(syn, submission_id)
 
     # Get the Synapse users to send an e-mail to
-    ids_to_notify = helpers.get_participant_id(syn, submission_id)
+    participant_id = helpers.get_participant_id(syn, submission_id)
 
     # Get the name of the participant(s)
-    participant_name = helpers.get_participant_name(syn, submission_id)
+    participant_name = helpers.get_participant_name(syn, participant_id)
 
     # Create the subject and body of the e-mail message, depending on
     # the notification type and submission status:
@@ -176,7 +176,7 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
             submission_annotations.reason,
         )
 
-    syn.sendMessage(userIds=ids_to_notify, messageSubject=subject, messageBody=body)
+    syn.sendMessage(userIds=participant_id, messageSubject=subject, messageBody=body)
 
 
 if __name__ == "__main__":

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -124,7 +124,7 @@ def get_annotations(syn: synapseclient.Synapse, submission_id: str) -> NamedTupl
     )
 
 
-def send_email(view_id: str, submission_id: str, email_with_score: str, notification_type: str):
+def send_email(view_id: str, submission_id: str, email_with_score: str, notification_type: str, project_name: str):
     """
     Sends an e-mail on the status of the individual submission
     to the submitting team or individual.
@@ -145,14 +145,17 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
     # Get the Synapse users to send an e-mail to
     ids_to_notify = helpers.get_participant_id(syn, submission_id)
 
+    # Get the name of the participant(s)
+    participant_name = helpers.get_participant_name(syn, submission_id)
+
     # Create the subject and body of the e-mail message, depending on
     # the notification type and submission status:
     if notification_type.upper() == "BEFORE":
         # Before-evaluation notification
         subject = f"Evaluation Started: {submission_id}"
         body = (
-            f"Dear participant,\n\n"
-            f"Your submission <b>{submission_id}</b> is now being evaluated. "
+            f"Dear {participant_name},\n\n"
+            f"Your submission <b>{submission_id}</b> for the {project_name} project is now being evaluated. "
             "We will notify you again once the evaluation completes.\n\n"
             "Thank you for your participation!\n\n"
             "The Challenge Organizers"
@@ -181,5 +184,6 @@ if __name__ == "__main__":
     submission_id = sys.argv[2]
     email_with_score = sys.argv[3]
     notification_type = sys.argv[4]
+    project_name = sys.argv[5]
 
-    send_email(view_id, submission_id, email_with_score, notification_type)
+    send_email(view_id, submission_id, email_with_score, notification_type, project_name)

--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -132,6 +132,8 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
     Arguments:
       view_id: The view Id of the Submission View on Synapse
       submission_id: The ID for an individual submission within an evaluation queue
+      email_with_score: Whether to include the score in the e-mail
+      notification_type: The type of notification to send (determines the subject and body of e-mail)
 
     """
     # Initiate connection to Synapse

--- a/modules/download_submission.nf
+++ b/modules/download_submission.nf
@@ -10,6 +10,7 @@ process DOWNLOAD_SUBMISSION {
     val submission_id
     val file_type_lower
     val ready
+    val ready
 
     output:
     tuple val(submission_id), path("*.${file_type_lower}")

--- a/modules/run_docker.nf
+++ b/modules/run_docker.nf
@@ -18,6 +18,7 @@ process RUN_DOCKER {
     val log_max_size
     val ready
     val ready
+    val ready
 
     output:
     tuple val(submission_id), path('output/*_predictions.{csv,zip}'), path('output/*.log')

--- a/modules/send_email.nf
+++ b/modules/send_email.nf
@@ -8,6 +8,7 @@ process SEND_EMAIL {
     input:
     val email_script
     val view_id
+    val project_name
     val submission_id
     val notification_type
     val email_with_score
@@ -15,6 +16,6 @@ process SEND_EMAIL {
 
     script:
     """
-    ${email_script} '${view_id}' '${submission_id}' '${email_with_score}' '${notification_type}'
+    ${email_script} '${view_id}' '${submission_id}' '${email_with_score}' '${notification_type}' '${project_name}'
     """
 }

--- a/modules/send_email.nf
+++ b/modules/send_email.nf
@@ -14,6 +14,9 @@ process SEND_EMAIL {
     val email_with_score
     val ready
 
+    output:
+    val "ready"
+
     script:
     """
     ${email_script} '${view_id}' '${submission_id}' '${email_with_score}' '${notification_type}' '${project_name}'

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,7 +28,7 @@ profiles {
     params.submissions = "9751432"
     params.view_id = "syn52576179"
     params.groundtruth_id = "syn65491926"
-    params.challenge_container = "ghcr.io/jaymedina/jenny-test-evaluation:latest"
+    params.challenge_container = "ghcr.io/jaymedina/test-evaluation:latest"
   }
   model_to_data_prototype {
     params.entry = 'model_to_data'
@@ -37,7 +37,7 @@ profiles {
     params.view_id = "syn53770151"
     params.data_folder_id = "syn51390589"
     params.groundtruth_id = "syn51390590"
-    params.challenge_container = "ghcr.io/jaymedina/test_model2data:latest"
+    params.challenge_container = "ghcr.io/jaymedina/test-evaluation:latest"
   }
   dynamic_challenge {
     params.entry = 'data_to_model'

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,6 +26,7 @@ profiles {
   data_to_model_prototype {
     params.entry = 'data_to_model'
     params.submissions = "9751432"
+    params.project_name = "DPE-testing"
     params.view_id = "syn52576179"
     params.groundtruth_id = "syn65491926"
     params.challenge_container = "ghcr.io/jaymedina/test-evaluation:latest"

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,7 +32,7 @@ profiles {
   }
   model_to_data_prototype {
     params.entry = 'model_to_data'
-    params.submissions = ""
+    params.submissions = "9744479"
     params.project_name = "DPE-testing"
     params.view_id = "syn53770151"
     params.data_folder_id = "syn51390589"

--- a/workflows/DATA_TO_MODEL.nf
+++ b/workflows/DATA_TO_MODEL.nf
@@ -44,7 +44,7 @@ workflow DATA_TO_MODEL {
     // Phase 1: Notify users that evaluation of their submission has begun
     UPDATE_SUBMISSION_STATUS_BEFORE_EVALUATION(submission_ch, "EVALUATION_IN_PROGRESS")
     if (params.send_email) {
-        SEND_EMAIL_BEFORE(params.email_script, params.view_id, submission_ch, "BEFORE", params.email_with_score, "ready")
+        SEND_EMAIL_BEFORE(params.email_script, params.view_id, params.project_name, submission_ch, "BEFORE", params.email_with_score, "ready")
     }
 
     // Phase 2: Prepare the data: Download the submission and stage the groundtruth data on S3

--- a/workflows/DATA_TO_MODEL.nf
+++ b/workflows/DATA_TO_MODEL.nf
@@ -49,7 +49,7 @@ workflow DATA_TO_MODEL {
 
     // Phase 2: Prepare the data: Download the submission and stage the groundtruth data on S3
     SYNAPSE_STAGE_GROUNDTRUTH(params.groundtruth_id, "groundtruth_${params.groundtruth_id}")
-    download_submission_outputs = DOWNLOAD_SUBMISSION(submission_ch, params.file_type_lower, UPDATE_SUBMISSION_STATUS_BEFORE_EVALUATION.output)
+    download_submission_outputs = DOWNLOAD_SUBMISSION(submission_ch, params.file_type_lower, UPDATE_SUBMISSION_STATUS_BEFORE_EVALUATION.output, SEND_EMAIL_BEFORE.output)
     //// Explicit output handling
     download_submission_id = download_submission_outputs.map { submission_id, predictions -> submission_id }
     download_submission_predictions = download_submission_outputs.map { submission_id, predictions -> predictions }

--- a/workflows/DATA_TO_MODEL.nf
+++ b/workflows/DATA_TO_MODEL.nf
@@ -43,9 +43,9 @@ workflow DATA_TO_MODEL {
 
     // Phase 1: Notify users that evaluation of their submission has begun
     UPDATE_SUBMISSION_STATUS_BEFORE_EVALUATION(submission_ch, "EVALUATION_IN_PROGRESS")
-    // if (params.send_email) {
-    //     SEND_EMAIL_BEFORE(params.email_script, params.view_id, submission_ch, "BEFORE", params.email_with_score, "ready")
-    // }
+    if (params.send_email) {
+        SEND_EMAIL_BEFORE(params.email_script, params.view_id, submission_ch, "BEFORE", params.email_with_score, "ready")
+    }
 
     // Phase 2: Prepare the data: Download the submission and stage the groundtruth data on S3
     SYNAPSE_STAGE_GROUNDTRUTH(params.groundtruth_id, "groundtruth_${params.groundtruth_id}")

--- a/workflows/DATA_TO_MODEL.nf
+++ b/workflows/DATA_TO_MODEL.nf
@@ -73,6 +73,6 @@ workflow DATA_TO_MODEL {
     ANNOTATE_SUBMISSION_AFTER_SCORE(score_outputs)
     //// Send email
     if (params.send_email) {
-        SEND_EMAIL_AFTER(params.email_script, params.view_id, submission_ch, "AFTER", params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+        SEND_EMAIL_AFTER(params.email_script, params.view_id, params.project_name, submission_ch, "AFTER", params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
     }
 }

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -46,7 +46,8 @@ include { SCORE } from '../modules/score.nf'
 include { ANNOTATE_SUBMISSION as ANNOTATE_SUBMISSION_AFTER_VALIDATE } from '../modules/annotate_submission.nf'
 include { ANNOTATE_SUBMISSION as ANNOTATE_SUBMISSION_AFTER_SCORE } from '../modules/annotate_submission.nf'
 include { ANNOTATE_SUBMISSION as ANNOTATE_SUBMISSION_AFTER_UPDATE_FOLDERS } from '../modules/annotate_submission.nf'
-include { SEND_EMAIL } from '../modules/send_email.nf'
+include { SEND_EMAIL as SEND_EMAIL_BEFORE } from '../modules/send_email.nf'
+include { SEND_EMAIL as SEND_EMAIL_AFTER } from '../modules/send_email.nf'
 
 workflow MODEL_TO_DATA {
 
@@ -54,6 +55,10 @@ workflow MODEL_TO_DATA {
     submission_ch = CREATE_SUBMISSION_CHANNEL()
 
     // Phase 1: Prepare the data for scoring and create output folders on Synapse
+    //          + Notify users that evaluation of their submission has begun
+    if (params.send_email) {
+        SEND_EMAIL_BEFORE(params.email_script, params.view_id, submission_ch, "BEFORE", params.email_with_score, "ready")
+    }
     SYNAPSE_STAGE_DATA(params.data_folder_id, "input")
     SYNAPSE_STAGE_GROUNDTRUTH(params.groundtruth_id, "groundtruth_${params.groundtruth_id}")
     CREATE_FOLDERS(submission_ch, params.project_name, params.private_folders)

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -65,7 +65,7 @@ workflow MODEL_TO_DATA {
     UPDATE_SUBMISSION_STATUS_BEFORE_RUN(submission_ch, "EVALUATION_IN_PROGRESS")
 
     // Phase 2: Running the Docker submission (runs after Phase 1 data staging)
-    run_docker_outputs = RUN_DOCKER(submission_ch, params.container_timeout, params.poll_interval, SYNAPSE_STAGE_DATA.output, params.cpus, params.memory, params.log_max_size, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output)
+    run_docker_outputs = RUN_DOCKER(submission_ch, params.container_timeout, params.poll_interval, SYNAPSE_STAGE_DATA.output, params.cpus, params.memory, params.log_max_size, CREATE_FOLDERS.output, UPDATE_SUBMISSION_STATUS_BEFORE_RUN.output, SEND_EMAIL_BEFORE.output)
     //// Explicit output handling
     run_docker_submission = run_docker_outputs.map { submission_id, predictions, logs -> submission_id }
     run_docker_files = run_docker_outputs.map { submission_id, predictions, logs -> tuple(predictions, logs) }

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -57,7 +57,7 @@ workflow MODEL_TO_DATA {
     // Phase 1: Prepare the data for scoring and create output folders on Synapse
     //          + Notify users that evaluation of their submission has begun
     if (params.send_email) {
-        SEND_EMAIL_BEFORE(params.email_script, params.view_id, submission_ch, "BEFORE", params.email_with_score, "ready")
+        SEND_EMAIL_BEFORE(params.email_script, params.view_id, params.project_name, submission_ch, "BEFORE", params.email_with_score, "ready")
     }
     SYNAPSE_STAGE_DATA(params.data_folder_id, "input")
     SYNAPSE_STAGE_GROUNDTRUTH(params.groundtruth_id, "groundtruth_${params.groundtruth_id}")
@@ -93,6 +93,6 @@ workflow MODEL_TO_DATA {
     ANNOTATE_SUBMISSION_AFTER_SCORE(score_outputs)
     //// Send email
     if (params.send_email) {
-        SEND_EMAIL_AFTER(params.email_script, params.view_id, score_submission, "AFTER", params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+        SEND_EMAIL_AFTER(params.email_script, params.view_id, params.project_name, score_submission, "AFTER", params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
     }
 }

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -18,9 +18,9 @@ params.poll_interval = "1"
 // The challenge task for which the submissions are made
 params.task_number = 1
 // The command used to execute the Challenge scoring script in the base directory of the challenge_container: e.g. `python3 path/to/score.py`
-params.execute_scoring = "python3 /usr/local/bin/score.py"
+params.execute_scoring = "python3 /home/user/score.py"
 // The command used to execute the Challenge validation script in the base directory of the challenge_container: e.g. `python3 path/to/validate.py`
-params.execute_validation = "python3 /usr/local/bin/validate.py"
+params.execute_validation = "python3 /home/user/validate.py"
 // Toggle email notification
 params.send_email = true
 // Set email script

--- a/workflows/MODEL_TO_DATA.nf
+++ b/workflows/MODEL_TO_DATA.nf
@@ -93,6 +93,6 @@ workflow MODEL_TO_DATA {
     ANNOTATE_SUBMISSION_AFTER_SCORE(score_outputs)
     //// Send email
     if (params.send_email) {
-        SEND_EMAIL(params.email_script, params.view_id, score_submission, "AFTER", params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+        SEND_EMAIL_AFTER(params.email_script, params.view_id, score_submission, "AFTER", params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
     }
 }


### PR DESCRIPTION
# **Problem:**

As requested by @vpchung, it would be nice for participants to be notified their submissions are being evaluated so they don't feel like they have to monitor the submission view all the time.

# **Solution:**

- [x] Re-introduce `SEND_EMAIL_BEFORE` to `DATA_TO_MODEL.nf`
- [x] Introduce `SEND_EMAIL_BEFORE` to `MODEL_TO_DATA.nf`

# **Testing:**

- [x] `DATA_TO_MODEL.nf` ([workflow run](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/4eB7rU1GCYlY6d))

<img width="622" alt="image" src="https://github.com/user-attachments/assets/4c23476f-2eb2-4f14-bb54-080a8e1d3033" />

- [x] `MODEL_TO_DATA.nf` ([workflow run](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/5z87WQJz3JhZ25))

<img width="624" alt="image" src="https://github.com/user-attachments/assets/69750702-5933-404a-9c60-4f96f946ac88" />
