### PR TITLE
[DPE-1267] Update Olfactory Challenge profiles

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -69,11 +69,19 @@ profiles {
     params.send_email = true
     params.email_with_score = "no"
   }
-  olfactory25_challenge_validate {
+  olfactory25_challenge_task1 {
     params.entry = 'data_to_model'
     params.project_name = 'DREAM Olfactory Mixtures Prediction Challenge 2025'
     params.view_id = "syn66279193"
-    params.groundtruth_id = "syn65916675"
+    params.groundtruth_id = "syn66479969"
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
+    params.email_script = "send_email.py"
+  }
+  olfactory25_challenge_task2 {
+    params.entry = 'data_to_model'
+    params.project_name = 'DREAM Olfactory Mixtures Prediction Challenge 2025'
+    params.view_id = "syn66484079"
+    params.groundtruth_id = "syn66479976"
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
     params.email_script = "send_email.py"
   }


### PR DESCRIPTION
# **Problem:**

1. The previous groundtruth entity for task 1 was deleted from Synapse, and replaced with a new one.
2. The challenge organizers would like to now have 2 simultaneously running tasks for the first round.

# **Solution:**

- [x] Point to the correct groundtruth entity for task 1
- [x] Add a new profile for the 2nd task for Olfactory, so we can create 2 simultaneously running DAGs on `orca-recipes`

# **Testing:**

I tested this with a dummy invalid submission. [Tower Run](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/26m2T7VwNN9tKu) ran through to completion with the latest scripts + the new profiles ✅ 

E-mails look right ✅ 

<img width="860" alt="image" src="https://github.com/user-attachments/assets/e1fefec1-e3a6-46a8-b6f5-893ec6544b0b" />

<img width="859" alt="image" src="https://github.com/user-attachments/assets/bd7fb325-ff18-4b78-b868-c76c9c500538" />

And annotations look good ✅ 

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/4fb98ce1-8a5d-434b-81b4-7228e4503322" />
