### PR TITLE
[DPE-1267] move `get_annotations` call in `send_email.py`

### DIFF
--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -139,9 +139,6 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
     # Initiate connection to Synapse
     syn = synapseclient.login()
 
-    # Get MODEL_TO_DATA annotations for the given submission
-    submission_annotations = get_annotations(syn, submission_id)
-
     # Get the Synapse user/team to send an e-mail to
     participant_id = helpers.get_participant_id(syn, submission_id)
 
@@ -151,7 +148,8 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
     # Create the subject and body of the e-mail message, depending on
     # the notification type and submission status:
     if notification_type.upper() == "BEFORE":
-        # Before-evaluation notification
+        # Before-evaluation notification...
+
         subject = f"Evaluation Started: {submission_id}"
         body = (
             f"Dear {participant_name},\n\n"
@@ -161,7 +159,11 @@ def send_email(view_id: str, submission_id: str, email_with_score: str, notifica
             "The Challenge Organizers"
         )
     else:
-        # After-evaluation notification
+        # After-evaluation notification...
+
+        # Get annotations for the given submission
+        submission_annotations = get_annotations(syn, submission_id)
+
         subject = (
             f"Evaluation Success: {submission_id}"
             if submission_annotations.status == "VALIDATED"


### PR DESCRIPTION
# **Problem:**

[Failed Tower Run](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/olfactory-challenge-project/watch/1AEkIBmQdF5sMu)

**The Cause**:

`get_annotations` should not have been called before the e-mail type (`BEFORE` vs `AFTER`) was established. The submissions are not annotated before the evaluation takes place, so this function fails for brand new submissions.

# **Solution:**

- [x] Move `get_annotations` until after e-mail type is established in the `if/else` block

# **Testing:**

A brand new submission for Task 2 is tested against, to ensure submissions without annotations don't break the `SEND_EMAIL_BEFORE` process...

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/174ab521-cdbb-4fa6-81bf-6367587ad5e5" />

[Successful Tower Run](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3hxzLHwE3odJs2)

E-mail ✅ 

<img width="847" alt="image" src="https://github.com/user-attachments/assets/6151e065-c650-4236-92bb-8370f3e81207" />

