### PR TITLE
[DPE-1267] Rely on output `submission_id`

### DIFF
--- a/workflows/DATA_TO_MODEL.nf
+++ b/workflows/DATA_TO_MODEL.nf
@@ -73,6 +73,6 @@ workflow DATA_TO_MODEL {
     ANNOTATE_SUBMISSION_AFTER_SCORE(score_outputs)
     //// Send email
     if (params.send_email) {
-        SEND_EMAIL_AFTER(params.email_script, params.view_id, params.project_name, submission_ch, "AFTER", params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
+        SEND_EMAIL_AFTER(params.email_script, params.view_id, params.project_name, score_submission, "AFTER", params.email_with_score, ANNOTATE_SUBMISSION_AFTER_SCORE.output)
     }
 }


### PR DESCRIPTION
# **Problem:**

A classic no-no: Using the submission channel as input rather than the submission ID from prior process outputs. This can create a mixup where the wrong e-mail is sent for a submission.

⚠️ Time-sensitive! I'd like a review before 6 PM ET May 14

# **Solution:**

- [x] Use the submission ID output from the previous process in the chain (`SCORE`), rather than the submission channel, for the `SEND_EMAIL_AFTER` input

# **Testing:**

Tested with 3 submissions from [Olfactory Task 1](https://www.synapse.org/Synapse:syn66279193/tables/)

Here is the [Tower Run](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/BLBfOlbsDfk22)

1. 9751837 is a docker submission (wrong entity type)
2. 9751838 is a CSV submission, but has the wrong column names
3. 9752007 is a TXT submission (wrong file extension type)

Results:

<img width="780" alt="image" src="https://github.com/user-attachments/assets/ebbf3607-17e1-4180-bb88-818d93d131f7" />

----

<img width="844" alt="image" src="https://github.com/user-attachments/assets/4129a848-5627-403a-9028-54c80fa71b1a" />

----

<img width="842" alt="image" src="https://github.com/user-attachments/assets/03a29327-3221-4aff-9b5c-5fe6474ccc3c" />

----

And, yes, annotations still look good

<img width="933" alt="image" src="https://github.com/user-attachments/assets/e5353dd2-95a7-4159-aa29-07653f86dd5e" />

