### PR TITLE
remove current_rank from score e-mail context

### DIFF
--- a/bin/send_email.py
+++ b/bin/send_email.py
@@ -112,7 +112,8 @@ def get_annotations(syn: synapseclient.Synapse, submission_id: str) -> NamedTupl
         "validation_errors",
         "validation_status",
         "predictions_id",
-        "docker_logs_id"
+        "docker_logs_id",
+        "current_rank"
     ]
     submission_scores = {
         key: submission_annotations.get(key)


### PR DESCRIPTION
# **Problem:**

A new annotation, `current_rank` has been introduced to the DREAM Olfactory challenge submission views for Task 1 & 2.

Currently we manually list the submission annotations we need to exclude from the "scores" dictionary that is used to list out the scores to the user in the final e-mail. The `current_rank` annotation needs to be added to that exclusion list so it's not added to the final score list, since it's not a score.

# **Solution:**

- [x] Add `current_rank` to list of non-score annotations so it doesn't show up as a "score" in the e-mail

# **Testing:**

### [BEFORE](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2LSuNcGjsP83kU)

<img width="861" alt="image" src="https://github.com/user-attachments/assets/badb3a21-2d38-4725-8e1c-c23f1f9d75cf" />

### [AFTER](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2NVsaQRm49lhT9)

<img width="853" alt="image" src="https://github.com/user-attachments/assets/18545ab0-6e76-469f-a53f-610a4c8cf82f" />
