### PR TITLE
[hotfix] fix user-submitted files with spaces

### DIFF
--- a/bin/download_submission.py
+++ b/bin/download_submission.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-
+import os
 import argparse
-import synapseclient
 
+import synapseclient
 from synapseclient.core.constants import concrete_types
 
 def get_args():
@@ -24,7 +24,11 @@ if __name__ == "__main__":
     submission = syn.getSubmission(submission_id, downloadLocation=".")
     entity_type = submission["entity"].concreteType
     file_path = submission["filePath"]
-    
+
+    file_path_no_spaces = file_path.replace(" ", "_")
+    if file_path != file_path_no_spaces:
+        os.rename(file_path, file_path_no_spaces)
+
     # TODO: Eventually we want to abstract this logic into the `make_invalid_file` function
     # in model-to-data's `run_docker.py`, and move that out somewhere else.
     invalid_file = f"INVALID_predictions.{file_type}"
@@ -34,7 +38,7 @@ if __name__ == "__main__":
         error_msg = (
             f"Only Files should be submitted. Submission {submission_id} type is: {entity_type}"
         )
-    elif not submission["filePath"].lower().endswith(file_type):
+    elif not file_path_no_spaces.lower().endswith(file_type):
         error_msg = f"Incorrect file type. File type should be {file_type.upper()}"
 
     if error_msg:

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,7 +28,7 @@ profiles {
     params.submissions = "9751432"
     params.project_name = "DPE-testing"
     params.view_id = "syn52576179"
-    params.groundtruth_id = "syn65491926"
+    params.groundtruth_id = "syn65491928"
     params.challenge_container = "ghcr.io/jaymedina/test-evaluation:latest"
   }
   model_to_data_prototype {

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,7 +28,7 @@ profiles {
     params.submissions = "9751432"
     params.project_name = "DPE-testing"
     params.view_id = "syn52576179"
-    params.groundtruth_id = "syn65491928"
+    params.groundtruth_id = "syn66400329"
     params.challenge_container = "ghcr.io/jaymedina/test-evaluation:latest"
   }
   model_to_data_prototype {


### PR DESCRIPTION
# **Problem:**

A user-submitted [Task 1](https://www.synapse.org/Synapse:syn66279193/tables/) submission (`9752595`) was made with a submission file name that contains spaces.

Because of the way Nextflow parses strings with spaces, the way the file path was getting fed into the `VALIDATE` process of the workflow was causing the organizers' validation script to raise a `FileNotFoundError` for this submission, causing the workflow to crash before completion.

See [Tower run](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/olfactory-challenge-project/watch/20m3KkF13Osptg) where this bug was surfaced.

# **Solution:**

- [x] Implement logic in `download_submissions.py` to remove spaces in the file path of a submission file

# **Testing:**

[BEFORE](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/1tsOanGZOTShOK)

<img width="558" alt="image" src="https://github.com/user-attachments/assets/be545e14-504c-4002-9994-0916060c48c2" />

[AFTER](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/3jG1RyA1wUz6xK) (space special character)

<img width="569" alt="image" src="https://github.com/user-attachments/assets/60e9a8b9-7ab7-43d0-b453-113b5e337c08" />

[AFTER](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/2CGVkctjrbHZt7) (other special character)

<img width="600" alt="image" src="https://github.com/user-attachments/assets/e87e6dcf-d746-4a7b-8e72-3b92eb68f4e1" />
