### PR TITLE
Add profiles for the DREAM AD Pathology Prediction Challenge

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -85,6 +85,14 @@ profiles {
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
     params.email_script = "send_email.py"
   }
+  dream_ad_pathology_prediction_challenge_leaderboard {
+    params.entry = 'model_to_data'
+    params.project_name = 'Prediction of Alzheimers Disease Pathology from scTranscriptomic Data DREAM Challenge'
+    params.view_id = "syn68232101"
+    params.groundtruth_id = "syn66479969"  // TODO
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/dream-ad-pathology-prediction:latest"
+    params.email_script = "send_email.py"
+  }
 	tower {
     process {
       withName: RUN_DOCKER {

--- a/nextflow.config
+++ b/nextflow.config
@@ -93,6 +93,17 @@ profiles {
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/dream-ad-pathology-prediction:latest"
     params.email_script = "send_email.py"
   }
+  dream_ad_pathology_prediction_challenge_final {
+    params.entry = 'model_to_data'
+    params.project_name = 'Prediction of Alzheimers Disease Pathology from scTranscriptomic Data DREAM Challenge'
+    params.view_id = "syn68232105"
+    params.groundtruth_id = "syn66479969"  // TODO
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/dream-ad-pathology-prediction:latest"
+    params.email_script = "send_email.py"
+    params.private_folders = "predictions"
+    params.send_email = true
+    params.email_with_score = "no"
+  }
 	tower {
     process {
       withName: RUN_DOCKER {

--- a/nextflow.config
+++ b/nextflow.config
@@ -85,20 +85,20 @@ profiles {
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
     params.email_script = "send_email.py"
   }
-  dream_ad_pathology_prediction_challenge_leaderboard {
+  sea_ad_dream_challenge_leaderboard {
     params.entry = 'model_to_data'
-    params.project_name = 'Prediction of Alzheimers Disease Pathology from scTranscriptomic Data DREAM Challenge'
+    params.project_name = 'SEA-AD DREAM Challenge - Predicting Alzheimers Pathology from scRNA-seq Data'
     params.view_id = "syn68232101"
     params.groundtruth_id = "syn66479969"  // TODO
-    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/dream-ad-pathology-prediction:latest"
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/sea-ad-dream:latest"
     params.email_script = "send_email.py"
   }
-  dream_ad_pathology_prediction_challenge_final {
+  sea_ad_dream_challenge_final {
     params.entry = 'model_to_data'
-    params.project_name = 'Prediction of Alzheimers Disease Pathology from scTranscriptomic Data DREAM Challenge'
+    params.project_name = 'SEA-AD DREAM Challenge - Predicting Alzheimers Pathology from scRNA-seq Data'
     params.view_id = "syn68232105"
     params.groundtruth_id = "syn66479969"  // TODO
-    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/dream-ad-pathology-prediction:latest"
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/sea-ad-dream:latest"
     params.email_script = "send_email.py"
     params.private_folders = "predictions"
     params.send_email = true


### PR DESCRIPTION
# **Problem:**

New m2d DREAM Challenge to be supported by ORCA/DPE: https://www.synapse.org/Synapse:syn66496696


# **Solution:**

Organizers are still planning the challenge, but as of right now, there will be a single task organized into two rounds.  This PR will introduce the two profiles, one for each round.

For the final round, my intention with the profile configuration (notably, L103-105) is so that emails are still sent in order to notify the submitters that their submission(s) has been evaluated, but scores are to remain hidden and _not_ shared (until after the winners are determined).  The `predictions` folder should also not be accessible to the participants. 

# **Testing:**

No tests performed.
