### PR TITLE
Add profiles for the EndALS 2025 Challenge

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -95,6 +95,18 @@ profiles {
     params.email_script = "send_email.py"
     params.private_folders = "predictions"
   }
+  end_als_2025_final {
+    params.entry = 'model_to_data'
+    params.project_name = 'EndALS Challenge 2025'
+    params.view_id = "syn66498809"
+    params.data_folder_id = "syn123"  // TODO
+    params.groundtruth_id = "syn123"  // TODO
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
+    params.email_script = "send_email.py"
+    params.private_folders = "predictions"
+    params.send_email = true
+    params.email_with_score = "no"
+  }
 	tower {
     process {
       withName: RUN_DOCKER {

--- a/nextflow.config
+++ b/nextflow.config
@@ -91,7 +91,7 @@ profiles {
     params.view_id = "syn66498809"
     params.data_folder_id = "syn123"  // TODO
     params.groundtruth_id = "syn123"  // TODO
-    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/end-als-2025:latest"
     params.email_script = "send_email.py"
     params.private_folders = "predictions"
   }
@@ -101,7 +101,7 @@ profiles {
     params.view_id = "syn66498809"
     params.data_folder_id = "syn123"  // TODO
     params.groundtruth_id = "syn123"  // TODO
-    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/end-als-2025:latest"
     params.email_script = "send_email.py"
     params.private_folders = "predictions"
     params.send_email = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -85,6 +85,16 @@ profiles {
     params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
     params.email_script = "send_email.py"
   }
+  end_als_2025_leaderboard {
+    params.entry = 'model_to_data'
+    params.project_name = 'EndALS Challenge 2025'
+    params.view_id = "syn66498809"
+    params.data_folder_id = "syn123"  // TODO
+    params.groundtruth_id = "syn123"  // TODO
+    params.challenge_container = "ghcr.io/sage-bionetworks-challenges/olfactory-mixtures-prediction:latest"
+    params.email_script = "send_email.py"
+    params.private_folders = "predictions"
+  }
 	tower {
     process {
       withName: RUN_DOCKER {


### PR DESCRIPTION
# **Problem:**

New m2d Challenge to be supported by ORCA/DPE: https://www.synapse.org/EndALS_2025


# **Solution:**

Organizers are still planning the challenge and data has yet to be migrated over to Synapse, but as of right now, there will be a single task organized into two rounds.  This PR will introduce the two profiles, one for each round. I am planning to use the same submission view for the two rounds, but I can change this if needed.

# **Testing:**

No tests performed.
