### PR TITLE
[hotfix] Refactor download submissions logic

### DIFF
--- a/bin/download_submission.py
+++ b/bin/download_submission.py
@@ -51,8 +51,6 @@ if __name__ == "__main__":
     entity_type = submission["entity"].concreteType
     file_path = submission["filePath"]
 
-    clean_file_name(file_path)
-
     # TODO: Eventually we want to abstract this logic into the `make_invalid_file` function
     # in model-to-data's `run_docker.py`, and move that out somewhere else.
     invalid_file = f"INVALID_predictions.{file_type}"
@@ -69,3 +67,5 @@ if __name__ == "__main__":
         with open(invalid_file, "w") as d:
             d.write(error_msg)
         print(error_msg)
+    else:
+        clean_file_name(file_path)


### PR DESCRIPTION
## Problem

A recent fix to the D2M pipeline involved adding a new function called `clean_file_name` into the logic of `download_submissions.py`.

This new logic was added in the wrong place, i.e. before it is determined whether or not the submission is a file. This caused our latest submission to break the pipeline, as it was a project submission.

## Solution

The solution is to refactor the logical flow inside `download_submissions.py`, so that cleaning up the file name happens only _after_ it's been confirmed that a file of the right kind has been submitted.

## Testing

### 1. Testing the script directly
 
**BEFORE**

```
(synapseclient) bash-3.2$ git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
(synapseclient) bash-3.2$ python download_submission.py -s '9753443' -f 'csv'

UPGRADE AVAILABLE

A more recent version of the Synapse Client (4.8.0) is available. Your version (4.4.0) can be upgraded by typing:
    pip install --upgrade synapseclient

Python Synapse Client version 4.8.0 release notes

https://python-docs.synapse.org/news/

Traceback (most recent call last):
  File "/Users/jmedina/Documents/forks/nf-synapse-challenge/bin/download_submission.py", line 54, in <module>
    clean_file_name(file_path)
  File "/Users/jmedina/Documents/forks/nf-synapse-challenge/bin/download_submission.py", line 28, in clean_file_name
    dir_name = os.path.dirname(file_path)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 152, in dirname
TypeError: expected str, bytes or os.PathLike object, not NoneType
(synapseclient) bash-3.2$ 
```

**AFTER**
```
(synapseclient) bash-3.2$ python download_submission.py -s '9753443' -f 'csv'

UPGRADE AVAILABLE

A more recent version of the Synapse Client (4.8.0) is available. Your version (4.4.0) can be upgraded by typing:
    pip install --upgrade synapseclient

Python Synapse Client version 4.8.0 release notes

https://python-docs.synapse.org/news/

Only Files should be submitted. Submission 9753443 type is: org.sagebionetworks.repo.model.Project
```

### 2. Testing from the pipeline

For good measure, I've also tested the pipeline itself with these new changes:

**[BEFORE](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/1PfIu0Qtsuhv0p)**

<img width="610" alt="image" src="https://github.com/user-attachments/assets/9a4ddb42-1d0f-432b-875c-345f08b1884d" />


**[AFTER](https://tower-dev.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/example-dev-project/watch/GCtrNgFNE2BLf)**